### PR TITLE
Fix Github Actions

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
         run: |
           cd build/release-mac-${{ matrix.arch }}
-          zip -r -y ../../macOS-${{ matrix.arch }}.zip melonDS.app
+          zip -r -y ../../macOS-${{ matrix.arch }}.zip khDaysMM.app
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -66,9 +66,9 @@ jobs:
         run: |
           unzip x86_64/*.zip -d x86_64
           unzip arm64/*.zip -d arm64
-          lipo {x86_64,arm64}/melonDS.app/Contents/MacOS/melonDS -create -output khDaysMM
-          cp -a arm64/melonDS.app khDaysMM.app
-          rm khDaysMM.app/Contents/MacOS/melonDS
+          lipo {x86_64,arm64}/khDaysMM.app/Contents/MacOS/khDaysMM -create -output khDaysMM
+          cp -a arm64/khDaysMM.app khDaysMM.app
+          rm khDaysMM.app/Contents/MacOS/khDaysMM
           cp khDaysMM khDaysMM.app/Contents/MacOS/khDaysMM
           codesign -s - --deep khDaysMM.app
           zip -r -y macOS-universal.zip khDaysMM.app

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -30,8 +30,8 @@ jobs:
         DESTDIR=AppDir cmake --install build
     - uses: actions/upload-artifact@v4
       with:
-        name: melonDS-ubuntu-x86_64
-        path: AppDir/usr/bin/melonDS
+        name: khDaysMM-ubuntu-x86_64
+        path: AppDir/usr/bin/khDaysMM
     - name: Fetch AppImage tools
       run: |
         wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
@@ -44,8 +44,8 @@ jobs:
         ./linuxdeploy-x86_64.AppImage --appdir AppDir --plugin qt --output appimage
     - uses: actions/upload-artifact@v4
       with:
-        name: melonDS-appimage-x86_64
-        path: melonDS*.AppImage
+        name: khDaysMM-appimage-x86_64
+        path: khDaysMM*.AppImage
 
   build-aarch64:
     name: aarch64
@@ -81,5 +81,5 @@ jobs:
           cmake --build build
       - uses: actions/upload-artifact@v4
         with:
-          name: melonDS-ubuntu-aarch64
-          path: build/melonDS
+          name: khDaysMM-ubuntu-aarch64
+          path: build/khDaysMM

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -38,7 +38,6 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: |
         cmake --build .
-        mv melonDS.exe khDaysMM.exe
 
     - uses: actions/upload-artifact@v1
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if (USE_VCPKG)
 	include(ConfigureVcpkg)
 endif()
 
-project(melonDS
+project(khDaysMM
     VERSION 0.2.1
     DESCRIPTION "DS emulator, sorta"
     HOMEPAGE_URL "https://github.com/vitor251093/KHDays_FM"

--- a/res/melon.rc.in
+++ b/res/melon.rc.in
@@ -6,8 +6,8 @@
 
 //include version information in .exe, modify these values to match your needs
 1 VERSIONINFO
-FILEVERSION ${melonDS_VERSION_MAJOR},${melonDS_VERSION_MINOR},${melonDS_VERSION_PATCH},0
-PRODUCTVERSION ${melonDS_VERSION_MAJOR},${melonDS_VERSION_MINOR},${melonDS_VERSION_PATCH},0
+FILEVERSION ${khDaysMM_VERSION_MAJOR},${khDaysMM_VERSION_MINOR},${khDaysMM_VERSION_PATCH},0
+PRODUCTVERSION ${khDaysMM_VERSION_MAJOR},${khDaysMM_VERSION_MINOR},${khDaysMM_VERSION_PATCH},0
 FILETYPE VFT_APP
 {
   BLOCK "StringFileInfo"
@@ -15,14 +15,14 @@ FILETYPE VFT_APP
 		BLOCK "040904E4"
 		{
 			VALUE "CompanyName", "Melon Factory of Kuribo64"
-			VALUE "FileVersion", "${melonDS_VERSION}"
+			VALUE "FileVersion", "${khDaysMM_VERSION}"
 			VALUE "FileDescription", "khDaysMM emulator"
 			VALUE "InternalName", "SDnolem"
 			VALUE "LegalCopyright", "2022-2024 VitorMM"
 			VALUE "LegalTrademarks", ""
 			VALUE "OriginalFilename", "khDaysMM.exe"
 			VALUE "ProductName", "khDaysMM"
-			VALUE "ProductVersion", "${melonDS_VERSION}"
+			VALUE "ProductVersion", "${khDaysMM_VERSION}"
 		}
 	}
   BLOCK "VarFileInfo"

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -94,37 +94,37 @@ fix_interface_includes(PkgConfig::SDL2 PkgConfig::LibArchive)
 
 add_compile_definitions(ARCHIVE_SUPPORT_ENABLED)
 
-add_executable(melonDS ${SOURCES_QT_SDL})
+add_executable(khDaysMM ${SOURCES_QT_SDL})
 
 option(USE_SYSTEM_LIBSLIRP "Use system libslirp instead of the bundled version" OFF)
 if (USE_SYSTEM_LIBSLIRP)
     pkg_check_modules(Slirp REQUIRED IMPORTED_TARGET slirp)
-    target_link_libraries(melonDS PRIVATE PkgConfig::Slirp)
+    target_link_libraries(khDaysMM PRIVATE PkgConfig::Slirp)
 else()
     add_subdirectory("../libslirp"
             "${CMAKE_BINARY_DIR}/libslirp"
             EXCLUDE_FROM_ALL)
-    target_link_libraries(melonDS PRIVATE slirp)
+    target_link_libraries(khDaysMM PRIVATE slirp)
 endif()
 
 if (WIN32)
-    target_link_libraries(melonDS PUBLIC opengl32)
+    target_link_libraries(khDaysMM PUBLIC opengl32)
 
-    target_sources(melonDS PRIVATE
+    target_sources(khDaysMM PRIVATE
         ../duckstation/gl/context_wgl.cpp
 
         ../glad/glad_wgl.c
     )
 
     if (MINGW AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
-        set_property(TARGET melonDS PROPERTY AUTORCC_OPTIONS "--no-zstd")
+        set_property(TARGET khDaysMM PROPERTY AUTORCC_OPTIONS "--no-zstd")
     endif()
 elseif (APPLE)
     if (NOT USE_QT6)
         find_library(COCOA_LIB Cocoa)
-        target_link_libraries(melonDS PRIVATE ${COCOA_LIB})
+        target_link_libraries(khDaysMM PRIVATE ${COCOA_LIB})
     endif()
-    target_sources(melonDS PRIVATE
+    target_sources(khDaysMM PRIVATE
         ../duckstation/gl/context_agl.mm
     )
 else()
@@ -141,14 +141,14 @@ else()
 
         find_package(Wayland REQUIRED Client)
 
-        target_compile_definitions(melonDS PRIVATE WAYLAND_ENABLED)
+        target_compile_definitions(khDaysMM PRIVATE WAYLAND_ENABLED)
 
-        target_sources(melonDS PRIVATE
+        target_sources(khDaysMM PRIVATE
             ../duckstation/gl/context_egl_wayland.cpp
         )
     endif()
 
-    target_sources(melonDS PRIVATE
+    target_sources(khDaysMM PRIVATE
         ../duckstation/gl/context_egl.cpp
         ../duckstation/gl/context_egl_x11.cpp
         ../duckstation/gl/context_glx.cpp
@@ -157,39 +157,39 @@ else()
         ../glad/glad_egl.c
         ../glad/glad_glx.c
     )
-    target_link_libraries(melonDS PRIVATE "${X11_LIBRARIES}" "${EGL_LIBRARIES}")
-    target_include_directories(melonDS PRIVATE "${X11_INCLUDE_DIR}")
+    target_link_libraries(khDaysMM PRIVATE "${X11_LIBRARIES}" "${EGL_LIBRARIES}")
+    target_include_directories(khDaysMM PRIVATE "${X11_INCLUDE_DIR}")
     add_compile_definitions(QAPPLICATION_CLASS=QApplication)
 endif()
 
 
 if (BUILD_STATIC)
-    qt_import_plugins(melonDS INCLUDE Qt::QSvgPlugin)
-    target_link_options(melonDS PRIVATE -static)
+    qt_import_plugins(khDaysMM INCLUDE Qt::QSvgPlugin)
+    target_link_options(khDaysMM PRIVATE -static)
 endif()
 
-target_include_directories(melonDS PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-target_include_directories(melonDS PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
-target_include_directories(melonDS PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+target_include_directories(khDaysMM PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(khDaysMM PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
+target_include_directories(khDaysMM PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 if (USE_QT6)
-    target_include_directories(melonDS PUBLIC ${Qt6Gui_PRIVATE_INCLUDE_DIRS})
+    target_include_directories(khDaysMM PUBLIC ${Qt6Gui_PRIVATE_INCLUDE_DIRS})
 else()
-    target_include_directories(melonDS PUBLIC ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
+    target_include_directories(khDaysMM PUBLIC ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 endif()
-target_link_libraries(melonDS PRIVATE core)
-target_link_libraries(melonDS PRIVATE PkgConfig::SDL2 PkgConfig::LibArchive PkgConfig::Zstd)
-target_link_libraries(melonDS PRIVATE ${QT_LINK_LIBS} ${CMAKE_DL_LIBS})
+target_link_libraries(khDaysMM PRIVATE core)
+target_link_libraries(khDaysMM PRIVATE PkgConfig::SDL2 PkgConfig::LibArchive PkgConfig::Zstd)
+target_link_libraries(khDaysMM PRIVATE ${QT_LINK_LIBS} ${CMAKE_DL_LIBS})
 
 if (WIN32)
     option(PORTABLE "Make a portable build that looks for its configuration in the current directory" ON)
 
     if (PORTABLE)
-        target_compile_definitions(melonDS PRIVATE WIN32_PORTABLE)
+        target_compile_definitions(khDaysMM PRIVATE WIN32_PORTABLE)
     endif()
 
     configure_file("${CMAKE_SOURCE_DIR}/res/melon.rc.in" "${CMAKE_BINARY_DIR}/res/melon.rc")
-    target_sources(melonDS PUBLIC "${CMAKE_BINARY_DIR}/res/melon.rc")
-    target_include_directories(melonDS PRIVATE "${CMAKE_BINARY_DIR}/res")
+    target_sources(khDaysMM PUBLIC "${CMAKE_BINARY_DIR}/res/melon.rc")
+    target_include_directories(khDaysMM PRIVATE "${CMAKE_BINARY_DIR}/res")
 
     if (${ARCHITECTURE} STREQUAL x86_64)
         set(WIN32_ARCHITECTURE amd64)
@@ -201,21 +201,21 @@ if (WIN32)
 
     configure_file("${CMAKE_SOURCE_DIR}/res/xp.manifest.in" "${CMAKE_BINARY_DIR}/res/xp.manifest")
 
-    target_link_libraries(melonDS PRIVATE ws2_32 iphlpapi)
-    set_target_properties(melonDS PROPERTIES LINK_FLAGS_DEBUG "-mconsole")
+    target_link_libraries(khDaysMM PRIVATE ws2_32 iphlpapi)
+    set_target_properties(khDaysMM PROPERTIES LINK_FLAGS_DEBUG "-mconsole")
 endif()
 
 if (APPLE)
-    target_sources(melonDS PRIVATE sem_timedwait.cpp)
+    target_sources(khDaysMM PRIVATE sem_timedwait.cpp)
 
     # Copy icon into the bundle
     set(RESOURCE_FILES "${CMAKE_SOURCE_DIR}/res/khDaysMM.icns")
-    target_sources(melonDS PUBLIC "${RESOURCE_FILES}")
+    target_sources(khDaysMM PUBLIC "${RESOURCE_FILES}")
 
-    set_target_properties(melonDS PROPERTIES
+    set_target_properties(khDaysMM PROPERTIES
         MACOSX_BUNDLE true
         MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/res/khDaysMM.plist.in
-        OUTPUT_NAME melonDS
+        OUTPUT_NAME khDaysMM
         RESOURCE "${RESOURCE_FILES}")
 
 
@@ -226,7 +226,7 @@ if (APPLE)
         if (MACOS_BUILD_DMG)
             set(DMGARG "--dmg")
         endif()
-        add_custom_command(TARGET melonDS POST_BUILD
+        add_custom_command(TARGET khDaysMM POST_BUILD
             COMMAND ${CMAKE_SOURCE_DIR}/tools/mac-libs.rb ${DMGARG} ${CMAKE_BINARY_DIR}
             COMMENT "Bundling macOS libraries...")
     endif()
@@ -240,10 +240,10 @@ if (UNIX AND NOT APPLE)
     endforeach()
 
     install(FILES ${CMAKE_SOURCE_DIR}/res/com.vitormm.khDaysMM.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
-    install(TARGETS melonDS BUNDLE DESTINATION ${CMAKE_BINARY_DIR} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+    install(TARGETS khDaysMM BUNDLE DESTINATION ${CMAKE_BINARY_DIR} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 
     if (NOT USE_QT6)
-        set_target_properties(melonDS PROPERTIES
+        set_target_properties(khDaysMM PROPERTIES
             INTERPROCEDURAL_OPTIMIZATION OFF
             INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
     endif()


### PR DESCRIPTION
This PR modifies the CMakeLists and github workflows so that it builds to a khDaysMM executable, fixing the broken appimage build and getting rid of some now unnecessary workarounds (it no longer needs to rename the melonDS executable in the Windows workflow before upload, for example).