### PR TITLE
Replacement bgm: support for loop points, fadein/fadeout, resume from last position

### DIFF
--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -23,6 +23,9 @@ set(SOURCES_QT_SDL
     MainWindow/MainWindowSettings.cpp
     MainWindow/MapButton.h
     MainWindow/resources/ds.qrc
+    MainWindow/AudioSource.cpp
+    MainWindow/AudioPlayer.cpp
+    MainWindow/AudioWavParser.cpp
     VideoSettingsDialog.cpp
     CameraSettingsDialog.cpp
     AudioSettingsDialog.cpp

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -89,8 +89,8 @@ void EmuThread::attachWindow(MainWindow* window)
         connect(this, SIGNAL(swapScreensToggle()), window->actScreenSwap, SLOT(trigger()));
     }
 
-    connect(this, SIGNAL(windowStartBgmMusic(QString)), window, SLOT(asyncStartBgmMusic(QString)));
-    connect(this, SIGNAL(windowStopBgmMusic()), window, SLOT(asyncStopBgmMusic()));
+    connect(this, SIGNAL(windowStartBgmMusic(quint16, bool, QString)), window, SLOT(asyncStartBgmMusic(quint16, bool, QString)));
+    connect(this, SIGNAL(windowStopBgmMusic(quint16)), window, SLOT(asyncStopBgmMusic(quint16)));
     connect(this, SIGNAL(windowPauseBgmMusic()), window, SLOT(asyncPauseBgmMusic()));
     connect(this, SIGNAL(windowUnpauseBgmMusic()), window, SLOT(asyncUnpauseBgmMusic()));
     
@@ -117,8 +117,8 @@ void EmuThread::detachWindow(MainWindow* window)
         disconnect(this, SIGNAL(swapScreensToggle()), window->actScreenSwap, SLOT(trigger()));
     }
 
-    disconnect(this, SIGNAL(windowStartBgmMusic(QString)), window, SLOT(asyncStartBgmMusic(QString)));
-    disconnect(this, SIGNAL(windowStopBgmMusic()), window, SLOT(asyncStopBgmMusic()));
+    disconnect(this, SIGNAL(windowStartBgmMusic(quint16, bool, QString)), window, SLOT(asyncStartBgmMusic(quint16, bool, QString)));
+    disconnect(this, SIGNAL(windowStopBgmMusic(quint16)), window, SLOT(asyncStopBgmMusic(quint16)));
     
     disconnect(this, SIGNAL(windowStartVideo(QString)), window, SLOT(asyncStartVideo(QString)));
     disconnect(this, SIGNAL(windowStopVideo()), window, SLOT(asyncStopVideo()));
@@ -770,11 +770,13 @@ void EmuThread::refreshPluginState()
     bool disableInvisibleFastMode = false;
 
     if (emuInstance->plugin->ShouldStopReplacementBgmMusic()) {
-        emit windowStopBgmMusic();
+        auto bgm = emuInstance->plugin->BackgroundMusicToStop();
+        emit windowStopBgmMusic(bgm);
     }
 
     if (emuInstance->plugin->ShouldStartReplacementBgmMusic()) {
-        auto bgm = emuInstance->plugin->CurrentBackgroundMusic();
+        u16 bgm = emuInstance->plugin->CurrentBackgroundMusic();
+        bool bShouldStoreResumePos = emuInstance->plugin->shouldStoreBgmResumePosition(bgm);
         if (bgm != 0) {
             std::string path = emuInstance->plugin->replacementBackgroundMusicFilePath("bgm" + std::to_string(bgm));
             if (path != "") {
@@ -785,16 +787,16 @@ void EmuThread::refreshPluginState()
 
                     emuStatus = emuStatus_Paused;
                     QString filePath = QString::fromUtf8(path.c_str());
-                    emit windowStartBgmMusic(filePath);
+                    emit windowStartBgmMusic(bgm, bShouldStoreResumePos, filePath);
                 }
                 else {
-                    QTimer::singleShot(emuInstance->plugin->delayBeforeStartReplacementBackgroundMusic(), mainWindow, [this, bgm, path]() {
+                    QTimer::singleShot(emuInstance->plugin->delayBeforeStartReplacementBackgroundMusic(), mainWindow, [this, bgm, bShouldStoreResumePos, path]() {
                         // disabling fast-foward, otherwise it will affect the cutscenes
                         emuInstance->setVSyncGL(true);
 
                         emuStatus = emuStatus_Paused;
                         QString filePath = QString::fromUtf8(path.c_str());
-                        emit windowStartBgmMusic(filePath);
+                        emit windowStartBgmMusic(bgm, bShouldStoreResumePos, filePath);
                     });
                 }
             }

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -157,8 +157,8 @@ signals:
 
     void syncVolumeLevel();
 
-    void windowStartBgmMusic(QString videoFilePath);
-    void windowStopBgmMusic();
+    void windowStartBgmMusic(quint16 bgmId, bool bStoreResumePos, QString videoFilePath);
+    void windowStopBgmMusic(quint16 bgmId);
     void windowPauseBgmMusic();
     void windowUnpauseBgmMusic();
 

--- a/src/frontend/qt_sdl/MainWindow/AudioPlayer.cpp
+++ b/src/frontend/qt_sdl/MainWindow/AudioPlayer.cpp
@@ -1,0 +1,87 @@
+#include "AudioPlayer.h"
+
+#include "AudioSource.h"
+
+#include <QAudioSink>
+#include <QAudioFormat>
+#include <QAudioSink>
+
+namespace melonMix {
+
+AudioPlayer::AudioPlayer(QObject *parent)
+    : QObject(parent)
+    , m_audioSource(new AudioSourceWav(this))
+{
+}
+
+bool AudioPlayer::loadFile(const QString &fileName)
+{
+    if (!m_audioSource->load(fileName)) {
+        return false;
+    }
+
+    QAudioFormat format;
+    format.setSampleRate(m_audioSource->getSampleRate());
+    format.setChannelCount(m_audioSource->getNumChannels());
+
+    auto sampleFormat = AudioSourceWav::bitsPerSampleToSampleFormat(m_audioSource->getBitsPerSample());
+    format.setSampleFormat(sampleFormat);
+
+    m_audioOutput.reset(new QAudioSink(format, this));
+
+    return true;
+}
+
+void AudioPlayer::setVolume(qreal value)
+{
+    if (m_audioOutput) {
+        m_audioOutput->setVolume(value);
+    }
+}
+
+void AudioPlayer::play()
+{
+    if (m_audioOutput) {
+        m_audioSource->onStarted();
+        m_audioOutput->start(m_audioSource.get());
+        m_playing = true;
+    }
+}
+
+void AudioPlayer::stop(int fadeOutMs)
+{
+    if (!m_audioOutput) {
+        return;
+    }
+
+    if (fadeOutMs == 0) {
+        onFadeOutCompleted();
+    } else {
+        m_audioSource->startFadeOut(fadeOutMs);
+    }
+}
+
+void AudioPlayer::onFadeOutCompleted()
+{
+    if (m_audioOutput) {
+        m_audioOutput->stop();
+        m_audioSource->onStopped();
+        m_playing = false;
+    }
+}
+
+void AudioPlayer::pause()
+{
+    if (m_audioOutput) {
+        m_audioOutput->suspend();
+    }
+}
+
+void AudioPlayer::resume()
+{
+    if (m_audioOutput) {
+        m_audioOutput->resume();
+    }
+}
+
+} // namespace melonMix

--- a/src/frontend/qt_sdl/MainWindow/AudioPlayer.h
+++ b/src/frontend/qt_sdl/MainWindow/AudioPlayer.h
@@ -13,11 +13,11 @@ class AudioPlayer : public QObject
 {
     Q_OBJECT
 public:
-    AudioPlayer(QObject* parent);
+    AudioPlayer(QObject* parent, quint16 bgmId);
 
     bool loadFile(const QString &fileName);
 
-    void play();
+    void play(qint64 resumePosition, int fadeInMs = 0);
     void stop(int fadeOutMs = 0);
 
     void pause();
@@ -25,7 +25,9 @@ public:
 
     void setVolume(qreal value);
 
+    quint16 getBgmId() const { return m_bgmId; }
     bool isPlaying() const { return m_playing; }
+    qint64 getCurrentPlayingPos() const;
 
 private slots:
     void onFadeOutCompleted();
@@ -34,6 +36,7 @@ private:
     QScopedPointer<AudioSourceWav> m_audioSource;
     QScopedPointer<QAudioSink> m_audioOutput;
 
+    quint16 m_bgmId = 0;
     bool m_playing = false;
 };
 

--- a/src/frontend/qt_sdl/MainWindow/AudioPlayer.h
+++ b/src/frontend/qt_sdl/MainWindow/AudioPlayer.h
@@ -1,0 +1,42 @@
+#ifndef AUDIOPLAYER_H
+#define AUDIOPLAYER_H
+
+#include <QObject>
+
+class QAudioSink;
+
+namespace melonMix {
+
+class AudioSourceWav;
+
+class AudioPlayer : public QObject
+{
+    Q_OBJECT
+public:
+    AudioPlayer(QObject* parent);
+
+    bool loadFile(const QString &fileName);
+
+    void play();
+    void stop(int fadeOutMs = 0);
+
+    void pause();
+    void resume();
+
+    void setVolume(qreal value);
+
+    bool isPlaying() const { return m_playing; }
+
+private slots:
+    void onFadeOutCompleted();
+
+private:
+    QScopedPointer<AudioSourceWav> m_audioSource;
+    QScopedPointer<QAudioSink> m_audioOutput;
+
+    bool m_playing = false;
+};
+
+} // namespace melonMix
+
+#endif // AUDIOPLAYER_H

--- a/src/frontend/qt_sdl/MainWindow/AudioSource.cpp
+++ b/src/frontend/qt_sdl/MainWindow/AudioSource.cpp
@@ -165,7 +165,7 @@ void AudioSourceWav::applyFadeOut(char* data, qint64 bytesRead)
     {
         m_fadeOutActive = false;
         QMetaObject::invokeMethod(parent(), "onFadeOutCompleted", Qt::QueuedConnection);
-        printf("bgm fade out completed: stopped");
+        printf("bgm fade out completed: stopped\n");
     }
 }
 

--- a/src/frontend/qt_sdl/MainWindow/AudioSource.cpp
+++ b/src/frontend/qt_sdl/MainWindow/AudioSource.cpp
@@ -1,0 +1,245 @@
+#include "AudioSource.h"
+#include "AudioWavParser.h"
+
+namespace melonMix {
+
+AudioSourceWav::AudioSourceWav(QObject *parent)
+    : QIODevice(parent)
+{
+}
+
+bool AudioSourceWav::load(const QString &fileName)
+{
+    m_file.setFileName(fileName);
+    if (!m_file.open(QIODevice::ReadOnly)) {
+        return false;
+    }
+    
+    if (!readWavHeader()) {
+        m_file.close();
+        return false;
+    }
+
+    bool bFoundMarkers = false;
+
+    AudioWavParser cueReader;
+    if (cueReader.readCuePoints(fileName.toStdString())) {
+        auto loopStartSample = cueReader.getLoopMarkerSample(AudioWavParser::EMarker::Begin);
+        auto loopEndSample = cueReader.getLoopMarkerSample(AudioWavParser::EMarker::End);
+        if (loopStartSample >= 0 && loopEndSample >= 0 && loopEndSample > loopStartSample) {
+            m_loopStartByte = m_dataStart + (loopStartSample * m_bytesPerFrame);
+            m_loopEndByte = m_dataStart + (loopEndSample * m_bytesPerFrame);
+            bFoundMarkers = true;
+        }
+    }
+
+    if (!bFoundMarkers) {
+        m_loopStartByte = m_dataStart;
+        m_loopEndByte = m_dataStart + m_dataSize;
+    }
+
+    open(QIODevice::ReadOnly);
+    return true;
+}
+
+void AudioSourceWav::onStarted()
+{
+    m_fadeOutActive = false;
+    m_fadeOutRemainingSamples = 0;
+    m_currentPos = m_dataStart;
+}
+
+void AudioSourceWav::onStopped()
+{
+    m_currentPos = m_dataStart;
+}
+
+qint64 AudioSourceWav::readData(char *data, qint64 maxSize)
+{
+    if (!m_file.isOpen()) {
+        return 0;
+    }
+
+    qint64 currentPos = m_file.pos();
+
+    if (currentPos > 0 && currentPos != m_currentPos) {
+        m_file.seek(m_currentPos);
+    }
+
+    qint64 bytesToRead = maxSize;
+
+    qint64 bytesRead = 0;
+
+    if (currentPos <= m_loopEndByte && currentPos + bytesToRead > m_loopEndByte) {
+        qint64 bytesBeforeLoop = m_loopEndByte - currentPos;
+
+        bytesRead = m_file.read(data, bytesBeforeLoop);
+        
+        if (bytesRead != bytesBeforeLoop) {
+            printf("Error or end of file\n");
+            return bytesRead;
+        }
+
+        printf("Loop bgm to start sample: %d\n", m_loopStartByte);
+
+        m_file.seek(m_loopStartByte);
+        currentPos = m_file.pos();
+
+        qint64 bytesAfterLoop = maxSize - bytesBeforeLoop;
+        auto additionalRead = m_file.read(data + bytesBeforeLoop, bytesAfterLoop);
+        bytesRead += additionalRead;
+    } else {
+        bytesRead = m_file.read(data, maxSize);
+
+        if (bytesRead < maxSize) {
+            m_file.seek(m_loopStartByte);
+            bytesRead += m_file.read(data + bytesRead, maxSize - bytesRead);
+        }
+    }
+
+    m_currentPos = m_file.pos();
+
+    if (m_fadeOutActive && bytesRead > 0) {
+        applyFadeOut(data, bytesRead);
+    }
+
+    return bytesRead;
+}
+
+void AudioSourceWav::startFadeOut(int durationMs)
+{
+    m_fadeOutActive = true;
+    m_fadeOutTotalSamples = (durationMs * m_sampleRate) / 1000;
+    m_fadeOutRemainingSamples = m_fadeOutTotalSamples;
+}
+
+void AudioSourceWav::applyFadeOut(char* data, qint64 bytesRead)
+{
+    int samplesPerFrame = m_numChannels;
+    int bytesPerFrame = m_bytesPerFrame;
+    int framesInBuffer = bytesRead / bytesPerFrame;
+    
+    for (int frame = 0; frame < framesInBuffer; frame++) {
+        float fadeProgress;
+        if (m_fadeOutRemainingSamples <= 0) {
+            fadeProgress = 0.0f;
+        } else {
+            fadeProgress = static_cast<float>(m_fadeOutRemainingSamples) / m_fadeOutTotalSamples;
+            fadeProgress = fadeProgress * fadeProgress;
+        }
+
+        for (int ch = 0; ch < m_numChannels; ch++) {
+            char* samplePtr = data + (frame * bytesPerFrame) + (ch * (m_bitsPerSample / 8));
+            
+            if (m_bitsPerSample == 16) {
+                int16_t* sample = reinterpret_cast<int16_t*>(samplePtr);
+                *sample = static_cast<int16_t>(*sample * fadeProgress);
+            } 
+            else if (m_bitsPerSample == 24) {
+                int32_t value = 0;
+                value = (static_cast<uint8_t>(samplePtr[0])) |
+                        (static_cast<uint8_t>(samplePtr[1]) << 8) |
+                        (static_cast<int8_t>(samplePtr[2]) << 16);
+
+                value = static_cast<int32_t>(value * fadeProgress);
+
+                samplePtr[0] = value & 0xFF;
+                samplePtr[1] = (value >> 8) & 0xFF;
+                samplePtr[2] = (value >> 16) & 0xFF;
+            }
+            else if (m_bitsPerSample == 32) {
+                int32_t* sample = reinterpret_cast<int32_t*>(samplePtr);
+                *sample = static_cast<int32_t>(*sample * fadeProgress);
+            }
+            else if (m_bitsPerSample == 8) {
+                uint8_t* sample = reinterpret_cast<uint8_t*>(samplePtr);
+                *sample = 128 + static_cast<uint8_t>((*sample - 128) * fadeProgress);
+            }
+        }
+
+        if (m_fadeOutRemainingSamples > 0)
+            m_fadeOutRemainingSamples--;
+    }
+
+    if (m_fadeOutRemainingSamples <= 0 && m_fadeOutActive)
+    {
+        m_fadeOutActive = false;
+        QMetaObject::invokeMethod(parent(), "onFadeOutCompleted", Qt::QueuedConnection);
+        printf("bgm fade out completed: stopped");
+    }
+}
+
+qint64 AudioSourceWav::bytesAvailable() const
+{
+    return m_file.bytesAvailable() + QIODevice::bytesAvailable() + m_sampleRate; 
+}
+
+QAudioFormat::SampleFormat AudioSourceWav::bitsPerSampleToSampleFormat(quint16 bitsPerSample)
+{
+    switch(bitsPerSample)
+    {
+        case 8: return QAudioFormat::UInt8;
+        case 16: return QAudioFormat::Int16;
+        case 24: return QAudioFormat::Int32;
+        case 32: return QAudioFormat::Int32;
+        default: return QAudioFormat::Unknown; // Unhandled
+    }
+}
+
+bool AudioSourceWav::readWavHeader()
+{
+    char riffHeader[12];
+    if (m_file.read(riffHeader, 12) != 12) {
+        return false;
+    }
+
+    if (memcmp(riffHeader, "RIFF", 4) != 0 || memcmp(riffHeader + 8, "WAVE", 4) != 0) {
+        return false;
+    }
+
+    bool foundFormat = false;
+    bool foundData = false;
+    
+    while (!foundData) {
+        char chunkHeader[8];
+        if (m_file.read(chunkHeader, 8) != 8) return false;
+        
+        char* chunkId = chunkHeader;
+        qint32 chunkSize = *reinterpret_cast<qint32*>(chunkHeader + 4);
+        
+        if (memcmp(chunkId, "fmt ", 4) == 0) {
+            QByteArray fmtData = m_file.read(chunkSize);
+            if (fmtData.size() != chunkSize) return false;
+
+            quint16 audioFormat = *reinterpret_cast<const quint16*>(fmtData.constData());
+            m_numChannels = *reinterpret_cast<const quint16*>(fmtData.constData() + 2);
+            m_sampleRate = *reinterpret_cast<const quint32*>(fmtData.constData() + 4);
+            m_bitsPerSample = *reinterpret_cast<const quint16*>(fmtData.constData() + 14);
+
+            m_bytesPerFrame = m_numChannels * (m_bitsPerSample / 8);
+
+            m_format.setSampleRate(m_sampleRate);
+            m_format.setChannelCount(m_numChannels);
+            
+            auto sampleFormat = bitsPerSampleToSampleFormat(m_bitsPerSample);
+            m_format.setSampleFormat(sampleFormat);
+
+            foundFormat = true;
+        } else if (memcmp(chunkId, "data", 4) == 0) {
+            m_dataStart = m_file.pos();
+            m_currentPos = m_dataStart;
+            m_dataSize = chunkSize;
+            foundData = true;
+        } else {
+            m_file.skip(chunkSize);
+        }
+
+        if (chunkSize % 2 != 0) {
+            m_file.skip(1);
+        }
+    }
+    
+    return foundFormat && foundData;
+}
+
+} // namespace melonMix

--- a/src/frontend/qt_sdl/MainWindow/AudioSource.h
+++ b/src/frontend/qt_sdl/MainWindow/AudioSource.h
@@ -16,7 +16,7 @@ class AudioSourceWav : public QIODevice
 public:
     AudioSourceWav(QObject *parent = nullptr);
 
-    void onStarted();
+    void onStarted(qint64 resumePosition, int fadeInMs);
     void onStopped();
 
     bool load(const QString &fileName);
@@ -34,12 +34,16 @@ public:
     quint32 getNumChannels() const { return m_numChannels; }
     quint32 getBitsPerSample() const { return m_bitsPerSample; }
 
+    qint64 getCurrentPlayingPos() const { return m_currentPos; }
+    void startFadeIn(int durationMs);
     void startFadeOut(int durationMs);
 
     static QAudioFormat::SampleFormat bitsPerSampleToSampleFormat(quint16 bitsPerSample);
 
 private:
-    void applyFadeOut(char* data, qint64 bytesRead);
+    enum EFadeType : quint8 { FadeIn, FadeOut };
+    void applyFade(EFadeType type, char* data, qint64 bytesRead);
+
     bool readWavHeader();
 
     QFile m_file;
@@ -57,6 +61,10 @@ private:
     qint64 m_loopEndByte = 0;
 
     qint64 m_currentPos = 0;
+
+    bool m_fadeInActive = false;
+    int m_fadeInRemainingSamples = 0;
+    int m_fadeInTotalSamples = 0;
 
     bool m_fadeOutActive = false;
     int m_fadeOutRemainingSamples = 0;

--- a/src/frontend/qt_sdl/MainWindow/AudioSource.h
+++ b/src/frontend/qt_sdl/MainWindow/AudioSource.h
@@ -1,0 +1,68 @@
+#ifndef AUDIOSOURCE_H
+#define AUDIOSOURCE_H
+
+#include <QAudioFormat>
+#include <QAudioOutput>
+#include <QAudioSink>
+#include <QIODevice>
+#include <QFile>
+#include <QBuffer>
+
+namespace melonMix {
+
+class AudioSourceWav : public QIODevice
+{
+    Q_OBJECT
+public:
+    AudioSourceWav(QObject *parent = nullptr);
+
+    void onStarted();
+    void onStopped();
+
+    bool load(const QString &fileName);
+
+
+    qint64 readData(char *data, qint64 maxSize) override;
+    qint64 writeData(const char*, qint64) override { return 0; }
+    qint64 size() const override { return m_file.size(); }
+    bool isSequential() const override { return false; }
+    bool atEnd() const override { return false; }
+    qint64 bytesAvailable() const override;
+
+
+    quint32 getSampleRate() const { return m_sampleRate; }
+    quint32 getNumChannels() const { return m_numChannels; }
+    quint32 getBitsPerSample() const { return m_bitsPerSample; }
+
+    void startFadeOut(int durationMs);
+
+    static QAudioFormat::SampleFormat bitsPerSampleToSampleFormat(quint16 bitsPerSample);
+
+private:
+    void applyFadeOut(char* data, qint64 bytesRead);
+    bool readWavHeader();
+
+    QFile m_file;
+    QAudioFormat m_format;
+    
+    qint64 m_dataStart = 0;
+    qint64 m_dataSize = 0;
+    
+    quint32 m_sampleRate = 0;
+    quint16 m_numChannels = 0;
+    quint16 m_bitsPerSample = 0;
+    quint16 m_bytesPerFrame = 0;
+
+    qint64 m_loopStartByte = 0;
+    qint64 m_loopEndByte = 0;
+
+    qint64 m_currentPos = 0;
+
+    bool m_fadeOutActive = false;
+    int m_fadeOutRemainingSamples = 0;
+    int m_fadeOutTotalSamples = 0;
+};
+
+} // namespace melonMix
+
+#endif // AUDIOSOURCE_H

--- a/src/frontend/qt_sdl/MainWindow/AudioWavParser.cpp
+++ b/src/frontend/qt_sdl/MainWindow/AudioWavParser.cpp
@@ -1,0 +1,134 @@
+#include "AudioWavParser.h"
+
+#include <iostream>
+#include <fstream>
+#include <cstring>
+#include <algorithm>
+
+namespace melonMix {
+
+struct WavHeader
+{
+    char riff[4];
+    u32 fileSize;
+    char wave[4];
+};
+
+struct WavFmtChunk
+{
+    u16 audioFormat;
+    u16 numChannels;
+    u32 sampleRate;
+    u32 byteRate;
+    u16 blockAlign;
+    u16 bitsPerSample;
+};
+
+struct ChunkHeader
+{
+    char id[4];
+    u32 size;
+};
+
+bool AudioWavParser::readCuePoints(const std::string& filePath)
+{
+    std::ifstream file(filePath, std::ios::binary);
+    if (!file.is_open()) {
+        printf("Error: Could not open file: %s\n", filePath.c_str());
+        return false;
+    }
+
+    WavHeader header;
+    file.read(reinterpret_cast<char*>(&header), sizeof(header));
+
+    if (std::strncmp(header.riff, "RIFF", 4) != 0 || std::strncmp(header.wave, "WAVE", 4) != 0) {
+        printf("Error: Not a valid WAV file: %s\n", filePath.c_str());
+        return false;
+    }
+    
+    bool foundFmt = false;
+    bool foundSmpl = false;
+
+    while (!file.eof()) {
+        ChunkHeader chunkHeader;
+        file.read(reinterpret_cast<char*>(&chunkHeader), sizeof(chunkHeader));
+
+        if (file.eof())
+            break;
+
+        if (std::strncmp(chunkHeader.id, "fmt ", 4) == 0) {
+            foundFmt = parseFmtChunk(file, chunkHeader.size);
+        } else if (std::strncmp(chunkHeader.id, "smpl", 4) == 0) {
+            foundSmpl = parseSmplChunk(file, chunkHeader.size);
+        } else {
+            file.seekg(chunkHeader.size, std::ios::cur);
+        }
+        
+        if (chunkHeader.size % 2 != 0) {
+            file.seekg(1, std::ios::cur);
+        }
+    }
+
+    if (!foundFmt) {
+        std::cerr << "Error: Format chunk not found in WAV file" << std::endl;
+        return false;
+    }
+    
+    if (!foundSmpl) {
+        std::cerr << "Warning: No cue points found in WAV file" << std::endl;
+        return false;
+    }
+
+    return foundSmpl;
+}
+
+s64 AudioWavParser::getLoopMarkerSample(EMarker marker) const
+{
+    if (m_hasSmplLoops && !m_smplChunk.loops.empty()) {
+        switch(marker)
+        {
+        case EMarker::Begin:
+            return m_smplChunk.loops[0].start;
+        case EMarker::End:
+            return m_smplChunk.loops[0].end;
+        }
+    }
+
+    return -1;
+}
+
+bool AudioWavParser::parseFmtChunk(std::ifstream& file, uint32_t size)
+{
+    WavFmtChunk fmtChunk;
+    file.read(reinterpret_cast<char*>(&fmtChunk), sizeof(fmtChunk));
+
+    if (size > sizeof(fmtChunk)) {
+        file.seekg(size - sizeof(fmtChunk), std::ios::cur);
+    }
+
+    return true;
+}
+
+bool AudioWavParser::parseSmplChunk(std::ifstream& file, uint32_t size)
+{
+    file.read(reinterpret_cast<char*>(&m_smplChunk), sizeof(uint32_t) * 9);
+
+    if (m_smplChunk.numSampleLoops > 0) {
+        m_smplChunk.loops.resize(m_smplChunk.numSampleLoops);
+
+        for (uint32_t i = 0; i < m_smplChunk.numSampleLoops; ++i) {
+            file.read(reinterpret_cast<char*>(&m_smplChunk.loops[i]), sizeof(WavSampleLoop));
+        }
+
+        m_hasSmplLoops = true;
+    }
+
+    uint32_t bytesRead = sizeof(uint32_t) * 9 + m_smplChunk.numSampleLoops * sizeof(WavSampleLoop);
+    if (size > bytesRead) {
+        file.seekg(size - bytesRead, std::ios::cur);
+    }
+    
+    return true;
+}
+
+} // namespace melonMix

--- a/src/frontend/qt_sdl/MainWindow/AudioWavParser.h
+++ b/src/frontend/qt_sdl/MainWindow/AudioWavParser.h
@@ -1,0 +1,56 @@
+#ifndef AUDIOWAVPARSER_H
+#define AUDIOWAVPARSER_H
+
+#include <string>
+#include <vector>
+#include "types.h"
+
+namespace melonMix {
+
+using namespace melonDS;
+
+struct WavSampleLoop
+{
+    uint32_t id;
+    uint32_t type;
+    uint32_t start;
+    uint32_t end;
+    uint32_t fraction;
+    uint32_t playCount;
+};
+
+struct WavSmplChunk
+{
+    uint32_t manufacturerId;
+    uint32_t productId;
+    uint32_t samplePeriod;
+    uint32_t midiUnityNote;
+    uint32_t midiPitchFraction;
+    uint32_t smpteFormat;
+    uint32_t smpteOffset;
+    uint32_t numSampleLoops;
+    uint32_t samplerData;
+    std::vector<WavSampleLoop> loops;
+};
+
+class AudioWavParser
+{
+public:
+    AudioWavParser() {}
+    
+    bool readCuePoints(const std::string& filePath);
+
+    enum EMarker : u8 { Begin, End };
+    s64 getLoopMarkerSample(EMarker marker) const;
+
+private:
+    bool parseFmtChunk(std::ifstream& file, uint32_t size);
+    bool parseSmplChunk(std::ifstream& file, uint32_t size);
+
+    bool m_hasSmplLoops;
+    WavSmplChunk m_smplChunk;
+};
+
+} // namespace melonMix
+
+#endif // AUDIOWAVPARSER_H

--- a/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
+++ b/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
@@ -47,16 +47,15 @@ public:
     ~MainWindowSettings();
 
 public slots:
-    void asyncStartBgmMusic(QString bgmMusicFilePath);
-    void asyncStopBgmMusic();
+    void asyncStartBgmMusic(quint16 bgmId, bool bStoreResumePos, QString bgmMusicFilePath);
+    void asyncStopBgmMusic(quint16 bgmId);
     void asyncPauseBgmMusic();
     void asyncUnpauseBgmMusic();
 
-    void startBgmMusic(QString bgmMusicFilePath);
-    void stopBgmMusic();
+    void startBgmMusic(quint16 bgmId, bool bStoreResumePos, QString bgmMusicFilePath);
+    void stopBgmMusic(quint16 bgmId);
     void pauseBgmMusic();
     void unpauseBgmMusic();
-
 
     void asyncStartVideo(QString videoFilePath);
     void asyncStopVideo();
@@ -67,6 +66,9 @@ public slots:
     void stopVideo();
     void pauseVideo();
     void unpauseVideo();
+
+private slots:
+    void onBgmFadeOutCompleted(melonMix::AudioPlayer* playerStopped);
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;
@@ -88,7 +90,9 @@ private:
     QScopedPointer<QAudioOutput> playerAudioOutput;
     QScopedPointer<QMediaPlayer> player;
 
-    QScopedPointer<melonMix::AudioPlayer> bgmPlayer;
+    QList<melonMix::AudioPlayer*> bgmPlayers;
+    quint16 bgmToResumeId = 0;
+    quint64 bgmToResumePosition = 0;
 
     void createVideoPlayer();
 

--- a/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
+++ b/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
@@ -80,13 +80,13 @@ protected:
     virtual void showGame() = 0;
 
 private:
-    Ui::MainWindowSettings* ui;
+    QScopedPointer<Ui::MainWindowSettings> ui;
     Config::Table& localCfg;
     EmuInstance* emuInstance;
 
-    QVideoWidget* playerWidget;
-    QAudioOutput* playerAudioOutput;
-    QMediaPlayer* player;
+    QScopedPointer<QVideoWidget> playerWidget;
+    QScopedPointer<QAudioOutput> playerAudioOutput;
+    QScopedPointer<QMediaPlayer> player;
 
     QScopedPointer<melonMix::AudioPlayer> bgmPlayer;
 

--- a/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
+++ b/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
@@ -31,6 +31,10 @@
 
 class EmuInstance;
 
+namespace melonMix {
+class AudioPlayer;
+}
+
 namespace Ui { class MainWindowSettings; }
 class MainWindowSettings;
 
@@ -84,11 +88,9 @@ private:
     QAudioOutput* playerAudioOutput;
     QMediaPlayer* player;
 
-    QMediaPlayer* bgmPlayer;
-    QAudioOutput* bgmPlayerAudioOutput;
+    QScopedPointer<melonMix::AudioPlayer> bgmPlayer;
 
     void createVideoPlayer();
-    void createBgmPlayer();
 
 };
 

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -840,6 +840,7 @@ bool Plugin::ShouldStopReplacementBgmMusic() {
     return false;
 }
 u16 Plugin::CurrentBackgroundMusic() {return _CurrentBackgroundMusic;};
+u16 Plugin::BackgroundMusicToStop() {return _BackgroundMusicToStop;};
 
 void Plugin::onReplacementBackgroundMusicStarted() {
     printf("Background music started\n");

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -214,12 +214,14 @@ public:
     bool ShouldUnpauseReplacementBgmMusic();
     bool ShouldStopReplacementBgmMusic();
     u16 CurrentBackgroundMusic();
+    u16 BackgroundMusicToStop();
 
     virtual std::string replacementBackgroundMusicFilePath(std::string name) {return "";}
 
     void onReplacementBackgroundMusicStarted();
 
     virtual void refreshBackgroundMusic() {}
+    virtual bool shouldStoreBgmResumePosition(u16 soundtrackId) const { return false; }
 
 
     virtual void refreshMouseStatus() {}
@@ -321,6 +323,7 @@ protected:
     bool _ShouldStopReplacementBgmMusic = false;
     u16 _CurrentBackgroundMusic = 0;
     u16 _LastSoundtrackId = 0;
+    u16 _BackgroundMusicToStop = 0;
 
 
     bool _ShouldGrabMouseCursor = false;

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -1998,6 +1998,7 @@ void PluginKingdomHeartsDays::refreshBackgroundMusic() {
         else if (soundtrackId == 0xFFFF) {
             if (_LastSoundtrackId != fakeSoundtrackId && _CurrentBackgroundMusic != 0) {
                 _ShouldStopReplacementBgmMusic = true;
+                _BackgroundMusicToStop = _CurrentBackgroundMusic;
                 printf("Stopping replacement song %d\n", _CurrentBackgroundMusic);
     
                 _CurrentBackgroundMusic = soundtrackId;
@@ -2006,6 +2007,7 @@ void PluginKingdomHeartsDays::refreshBackgroundMusic() {
         }
         else {
             _ShouldStopReplacementBgmMusic = true;
+            _BackgroundMusicToStop = _CurrentBackgroundMusic;
 
             if (replacementAvailable) {
                 u32 address = getAnyByCart(SONG_ADDRESS_US, SONG_ADDRESS_EU, SONG_ADDRESS_JP, SONG_ADDRESS_JP_REV1);
@@ -2034,6 +2036,12 @@ void PluginKingdomHeartsDays::refreshBackgroundMusic() {
         _CurrentBackgroundMusic = soundtrackId;
         _LastSoundtrackId = soundtrackId;
     }
+}
+
+bool PluginKingdomHeartsDays::shouldStoreBgmResumePosition(u16 soundtrackId) const
+{
+    static std::vector<u16> ids = { 2, 5, 7, 9, 11, 15, 16, 33 };
+    return (std::find(ids.begin(), ids.end(), soundtrackId) != ids.end());
 }
 
 int PluginKingdomHeartsDays::delayBeforeStartReplacementBackgroundMusic() {

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -2017,6 +2017,12 @@ void PluginKingdomHeartsDays::refreshBackgroundMusic() {
                 _CurrentBackgroundMusic = soundtrackId;
                 _LastSoundtrackId = soundtrackId;
             }
+            else
+            {
+                // No replacement available, resetting
+                _CurrentBackgroundMusic = soundtrackId;
+                _LastSoundtrackId = soundtrackId;
+            }
         }
     }
     else {

--- a/src/plugins/PluginKingdomHeartsDays.h
+++ b/src/plugins/PluginKingdomHeartsDays.h
@@ -137,7 +137,8 @@ private:
     bool canReturnToGameAfterReplacementCutscene();
 
     u16 detectMidiBackgroundMusic();
-    void refreshBackgroundMusic();
+    void refreshBackgroundMusic() override;
+    bool shouldStoreBgmResumePosition(u16 soundtrackId) const override;
 
     void refreshMouseStatus();
 


### PR DESCRIPTION
This set of changes is meant to enhance support for replacement background music. Here are the key points:
- a new class AudioWavParser gets the loop points from the wav header
- we now create an AudioPlayer which uses a AudioSourceWav (both are custom classes), to perform sample-accurate loops. This replaces the previous QMediaPlayer.
- also fixed the bug when a replacement track previously played, but wouldn't play again later (some properties were not properly reset)
- custom behaviour for "quiet world" tracks: when we switch to Combat, we store the previous playing position of the background track, and when combat ends, we resume to that previous position. This offset gets reset when we switch to a different world.
- proper handling of cross-fades between tracks: 600ms FadeOut of current track, and 600ms FadeIn of next track (only when resuming. Start from position 0 doesn't apply a FadeIn). This requires 2 AudioPlayers to be instantiated simultaneously for a short period. We can customize those durations later.

I've tested those changes in Days with a few tracks provided by Sandwich and my own custom tracks.