### PR TITLE
Music replacement fixes and improvements

### DIFF
--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -94,7 +94,8 @@ void EmuThread::attachWindow(MainWindow* window)
     connect(this, SIGNAL(windowPauseBgmMusic()), window, SLOT(asyncPauseBgmMusic()));
     connect(this, SIGNAL(windowUnpauseBgmMusic()), window, SLOT(asyncUnpauseBgmMusic()));
     connect(this, SIGNAL(windowUpdateBgmMusicVolume(quint8)), window, SLOT(asyncUpdateBgmMusicVolume(quint8)));
-    
+    connect(this, SIGNAL(windowStopAllBgm()), window, SLOT(asyncStopAllBgm()));
+
     connect(this, SIGNAL(windowStartVideo(QString)), window, SLOT(asyncStartVideo(QString)));
     connect(this, SIGNAL(windowStopVideo()), window, SLOT(asyncStopVideo()));
     connect(this, SIGNAL(windowPauseVideo()), window, SLOT(asyncPauseVideo()));
@@ -123,6 +124,7 @@ void EmuThread::detachWindow(MainWindow* window)
     disconnect(this, SIGNAL(windowPauseBgmMusic()), window, SLOT(asyncPauseBgmMusic()));
     disconnect(this, SIGNAL(windowUnpauseBgmMusic()), window, SLOT(asyncUnpauseBgmMusic()));
     disconnect(this, SIGNAL(windowUpdateBgmMusicVolume(quint8)), window, SLOT(asyncUpdateBgmMusicVolume(quint8)));
+    disconnect(this, SIGNAL(windowStopAllBgm()), window, SLOT(asyncStopAllBgm()));
 
     disconnect(this, SIGNAL(windowStartVideo(QString)), window, SLOT(asyncStartVideo(QString)));
     disconnect(this, SIGNAL(windowStopVideo()), window, SLOT(asyncStopVideo()));
@@ -193,6 +195,7 @@ void EmuThread::run()
                 lastVideoRenderer = -1;
                 videoSettingsDirty = true;
 
+                emit windowStopAllBgm();
                 emuInstance->plugin = Plugins::PluginManager::load(gamecode);
                 emuInstance->plugin->setNds(emuInstance->getNDS());
                 emuInstance->plugin->onLoadROM();

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -781,11 +781,6 @@ void EmuThread::refreshPluginState()
         auto* plugin = emuInstance->plugin;
 
         if (plugin->shouldStartBackgroundMusic()) {
-            // disabling fast-forward, otherwise it will affect the cutscenes
-            emuInstance->setVSyncGL(true);
-
-            emuStatus = emuStatus_Running;
-
             u16 bgm = plugin->getCurrentBackgroundMusic();
             std::string path = plugin->getReplacementBackgroundMusicFilePath(bgm);
 

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -157,10 +157,11 @@ signals:
 
     void syncVolumeLevel();
 
-    void windowStartBgmMusic(quint16 bgmId, bool bStoreResumePos, QString videoFilePath);
-    void windowStopBgmMusic(quint16 bgmId);
+    void windowStartBgmMusic(quint16 bgmId, quint8 volume, bool bStoreResumePos, quint32 delayAtStart, QString filePath);
+    void windowStopBgmMusic(quint16 bgmId, bool bStoreResumePos, bool bShouldForceStop);
     void windowPauseBgmMusic();
     void windowUnpauseBgmMusic();
+    void windowUpdateBgmMusicVolume(quint8 volume);
 
     void windowStartVideo(QString videoFilePath);
     void windowStopVideo();

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -162,6 +162,7 @@ signals:
     void windowPauseBgmMusic();
     void windowUnpauseBgmMusic();
     void windowUpdateBgmMusicVolume(quint8 volume);
+    void windowStopAllBgm();
 
     void windowStartVideo(QString videoFilePath);
     void windowStopVideo();

--- a/src/frontend/qt_sdl/MainWindow/AudioPlayer.cpp
+++ b/src/frontend/qt_sdl/MainWindow/AudioPlayer.cpp
@@ -33,17 +33,17 @@ bool AudioPlayer::loadFile(const QString &fileName)
     return true;
 }
 
-void AudioPlayer::setVolume(qreal value)
+void AudioPlayer::setVolume(qreal value, int durationInMs)
 {
     if (m_audioOutput) {
-        m_audioOutput->setVolume(value);
+        m_audioSource->setVolume(value, durationInMs);
     }
 }
 
-void AudioPlayer::play(qint64 resumePosition, int fadeInMs)
+void AudioPlayer::play(qint64 resumePosition, qreal volume, int fadeInMs)
 {
     if (m_audioOutput) {
-        m_audioSource->onStarted(resumePosition, fadeInMs);
+        m_audioSource->onStarted(resumePosition, volume, fadeInMs);
         m_audioOutput->start(m_audioSource.get());
         m_playing = true;
     }

--- a/src/frontend/qt_sdl/MainWindow/AudioPlayer.h
+++ b/src/frontend/qt_sdl/MainWindow/AudioPlayer.h
@@ -17,13 +17,13 @@ public:
 
     bool loadFile(const QString &fileName);
 
-    void play(qint64 resumePosition, int fadeInMs = 0);
-    void stop(int fadeOutMs = 0);
+    void play(qint64 resumePosition, qreal volume, int fadeInMs);
+    void stop(int fadeOutMs);
 
     void pause();
     void resume();
 
-    void setVolume(qreal value);
+    void setVolume(qreal value, int durationInMs);
 
     quint16 getBgmId() const { return m_bgmId; }
     bool isPlaying() const { return m_playing; }

--- a/src/frontend/qt_sdl/MainWindow/AudioSource.h
+++ b/src/frontend/qt_sdl/MainWindow/AudioSource.h
@@ -16,7 +16,7 @@ class AudioSourceWav : public QIODevice
 public:
     AudioSourceWav(QObject *parent = nullptr);
 
-    void onStarted(qint64 resumePosition, int fadeInMs);
+    void onStarted(qint64 resumePosition, qreal volume, int fadeInMs);
     void onStopped();
 
     bool load(const QString &fileName);
@@ -35,14 +35,14 @@ public:
     quint32 getBitsPerSample() const { return m_bitsPerSample; }
 
     qint64 getCurrentPlayingPos() const { return m_currentPos; }
-    void startFadeIn(int durationMs);
+    void startFadeIn(qreal volume, int durationMs);
     void startFadeOut(int durationMs);
+    void setVolume(double newVolume, int durationMs);
 
     static QAudioFormat::SampleFormat bitsPerSampleToSampleFormat(quint16 bitsPerSample);
 
 private:
-    enum EFadeType : quint8 { FadeIn, FadeOut };
-    void applyFade(EFadeType type, char* data, qint64 bytesRead);
+    void applyVolume(char* buffer, int64_t numSamples);
 
     bool readWavHeader();
 
@@ -62,13 +62,14 @@ private:
 
     qint64 m_currentPos = 0;
 
-    bool m_fadeInActive = false;
-    int m_fadeInRemainingSamples = 0;
-    int m_fadeInTotalSamples = 0;
+    enum class EStatus : quint8 { Playing, Stopping, Stopped };
+    EStatus m_status = EStatus::Stopped;
 
-    bool m_fadeOutActive = false;
-    int m_fadeOutRemainingSamples = 0;
-    int m_fadeOutTotalSamples = 0;
+    double m_currentVolume = 1.0;
+    double m_targetVolume = 1.0;
+    double m_volumeIncrement = 0.0;
+    int64_t m_samplesRemaining = 0;
+    int64_t m_totalTransitionSamples = 0;
 };
 
 } // namespace melonMix

--- a/src/frontend/qt_sdl/MainWindow/MainWindowSettings.cpp
+++ b/src/frontend/qt_sdl/MainWindow/MainWindowSettings.cpp
@@ -198,6 +198,20 @@ void MainWindowSettings::unpauseBgmMusic()
     }
 }
 
+void MainWindowSettings::asyncStopAllBgm()
+{
+    QMetaObject::invokeMethod(this, "stopAllBgm", Qt::QueuedConnection);
+}
+
+void MainWindowSettings::stopAllBgm()
+{
+    printf("Stop all bgm\n");
+
+    for(auto* player : bgmPlayers) {
+        player->stop(0);
+    }
+}
+
 void MainWindowSettings::onBgmFadeOutCompleted(melonMix::AudioPlayer* playerStopped)
 {
     for(auto it = bgmPlayers.begin(); it != bgmPlayers.end();) {

--- a/src/frontend/qt_sdl/MainWindow/MainWindowSettings.cpp
+++ b/src/frontend/qt_sdl/MainWindow/MainWindowSettings.cpp
@@ -104,8 +104,6 @@ void MainWindowSettings::startBgmMusic(quint16 bgmId, quint8 volume, bool bResum
     bgmPlayer->play(startPosition, initialVolume, fadeIn);
     printf("Starting replacement song %d %svolume: %.3f\n", bgmId, (bResumePos ? "(Resumed with fadein) " : ""), initialVolume);
 
-    emuInstance->plugin->onReplacementBackgroundMusicStarted();
-
     bgmPlayers.append(bgmPlayer);
 }
 

--- a/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
+++ b/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
@@ -47,15 +47,18 @@ public:
     ~MainWindowSettings();
 
 public slots:
-    void asyncStartBgmMusic(quint16 bgmId, bool bStoreResumePos, QString bgmMusicFilePath);
-    void asyncStopBgmMusic(quint16 bgmId);
+    void asyncStartBgmMusic(quint16 bgmId, quint8 volume, bool bResumePos, quint32 delayAtStart, QString bgmMusicFilePath);
+    void asyncStopBgmMusic(quint16 bgmId, bool bStoreResumePos, bool bShouldForceStop);
     void asyncPauseBgmMusic();
     void asyncUnpauseBgmMusic();
+    void asyncUpdateBgmMusicVolume(quint8 ramVolume);
 
-    void startBgmMusic(quint16 bgmId, bool bStoreResumePos, QString bgmMusicFilePath);
-    void stopBgmMusic(quint16 bgmId);
+    void startBgmMusic(quint16 bgmId, quint8 volume, bool bResumePos, QString bgmMusicFilePath);
+    void stopBgmMusic(quint16 bgmId, bool bStoreResumePos, bool bShouldForceStop);
     void pauseBgmMusic();
     void unpauseBgmMusic();
+
+    void updateBgmMusicVolume(quint8 ramVolume);
 
     void asyncStartVideo(QString videoFilePath);
     void asyncStopVideo();
@@ -69,6 +72,7 @@ public slots:
 
 private slots:
     void onBgmFadeOutCompleted(melonMix::AudioPlayer* playerStopped);
+    void startBgmMusicDelayed(quint16 bgmId, quint8 volume, bool bResumePos, QString bgmMusicFilePath);
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;
@@ -91,11 +95,12 @@ private:
     QScopedPointer<QMediaPlayer> player;
 
     QList<melonMix::AudioPlayer*> bgmPlayers;
+    QScopedPointer<QTimer> delayedBgmStart;
     quint16 bgmToResumeId = 0;
     quint64 bgmToResumePosition = 0;
 
     void createVideoPlayer();
-
+    qreal getBgmMusicVolume(quint8 ramVolume);
 };
 
 #endif // MAINWINDOWSETTINGS_H

--- a/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
+++ b/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
@@ -52,11 +52,13 @@ public slots:
     void asyncPauseBgmMusic();
     void asyncUnpauseBgmMusic();
     void asyncUpdateBgmMusicVolume(quint8 ramVolume);
+    void asyncStopAllBgm();
 
     void startBgmMusic(quint16 bgmId, quint8 volume, bool bResumePos, QString bgmMusicFilePath);
     void stopBgmMusic(quint16 bgmId, bool bStoreResumePos, bool bShouldForceStop);
     void pauseBgmMusic();
     void unpauseBgmMusic();
+    void stopAllBgm();
 
     void updateBgmMusicVolume(quint8 ramVolume);
 

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -47,6 +47,8 @@
 namespace Plugins
 {
 
+u16 Plugin::BGM_INVALID_ID = 0xFFFF;
+
 void Plugin::onLoadROM() {
     stopBackgroundMusic(true);
     _SoundtrackState = EMidiState::Stopped;
@@ -873,13 +875,13 @@ std::string Plugin::getReplacementBackgroundMusicFilePath(u16 id) {
 }
 
 void Plugin::stopBackgroundMusic(bool bImmediateStop) {
-    if (_CurrentBackgroundMusic > 0) {
+    if (_CurrentBackgroundMusic != BGM_INVALID_ID) {
         u16 resumeSlot = getMidiBgmToResumeId();
-        _StoreBackgroundMusicPosition = (resumeSlot == _CurrentBackgroundMusic && resumeSlot != 0xFFFF);
+        _StoreBackgroundMusicPosition = (resumeSlot == _CurrentBackgroundMusic && resumeSlot != BGM_INVALID_ID);
         _ShouldStopReplacementBgmMusic = true;
         _BackgroundMusicToStop = _CurrentBackgroundMusic;
         _ForceStopMusic = bImmediateStop;
-        _CurrentBackgroundMusic = 0;
+        _CurrentBackgroundMusic = BGM_INVALID_ID;
     }
     _MuteSeqBgm = false;
 }
@@ -928,11 +930,11 @@ void Plugin::refreshBackgroundMusic() {
                     _ShouldStartReplacementBgmMusic = true;
                     _CurrentBackgroundMusic = bgmId;
                     u16 bgmResumeId = getMidiBgmToResumeId();
-                    _ResumeBackgroundMusicPosition = (bgmResumeId == _CurrentBackgroundMusic && bgmResumeId != 0xFFFF);
+                    _ResumeBackgroundMusicPosition = (bgmResumeId == _CurrentBackgroundMusic && bgmResumeId != BGM_INVALID_ID);
                     _BackgroundMusicDelayAtStart = delayBeforeStartReplacementBackgroundMusic();
                     _MuteSeqBgm = true;
                 } else {
-                    _CurrentBackgroundMusic = 0;
+                    _CurrentBackgroundMusic = BGM_INVALID_ID;
                 }
             }
             break;
@@ -958,7 +960,7 @@ void Plugin::refreshBackgroundMusic() {
         _ShouldUpdateReplacementBgmMusicVolume = true;
     }
 
-    if (_MuteSeqBgm && _CurrentBackgroundMusic > 0) {
+    if (_MuteSeqBgm && _CurrentBackgroundMusic != BGM_INVALID_ID) {
         muteSongSequence(_CurrentBackgroundMusic);
     }
 }
@@ -985,7 +987,7 @@ void Plugin::muteSongSequence(u16 bgmId) {
     u32 songSize = nds->ARM9Read32(entryAddress);
     u32 songAddress = nds->ARM9Read32(entryAddress + 4);
     if (songAddress == 0) {
-        printf("Error: SSEQ %d is not loaded!!!\n", bgmId);
+        //printf("Error: SSEQ %d is not loaded!!!\n", bgmId);
         return;
     }
 
@@ -1019,7 +1021,7 @@ void Plugin::muteSongSequence(u16 bgmId) {
             nds->ARM7Write32(addr, 0x00);
         }
 
-        printf("Music SSEQ: Muted bgm %d (erased %d bytes)\n", bgmId, endErase - startErase);
+        //printf("Music SSEQ: Muted bgm %d (erased %d bytes)\n", bgmId, endErase - startErase);
     }
 }
 

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -324,7 +324,7 @@ bool Plugin::togglePause()
         }
         return true;
     }
-    if (_RunningReplacementBgmMusic) {
+    if (isBackgroundMusicPlaying()) {
         if (_PausedReplacementBgmMusic) {
             _ShouldUnpauseReplacementBgmMusic = true;
         }
@@ -843,55 +843,39 @@ void Plugin::onReturnToGameAfterCutscene() {
     }
 }
 
-bool Plugin::ShouldStartReplacementBgmMusic() {
-    if (_ShouldStartReplacementBgmMusic) {
-        _ShouldStartReplacementBgmMusic = false;
-        return true;
-    }
-    return false;
-}
 int Plugin::delayBeforeStartReplacementBackgroundMusic() {
     return 0;
 }
-bool Plugin::StartedReplacementBgmMusic() {
-    if (_StartedReplacementBgmMusic) {
-        _StartedReplacementBgmMusic = false;
-        return true;
+
+std::string Plugin::getReplacementBackgroundMusicFilePath(u16 id) {
+    std::string filename = "bgm" + std::to_string(id) + ".wav";
+    std::filesystem::path _assetsFolderPath = assetsFolderPath();
+    std::filesystem::path fullPath = _assetsFolderPath / "audio" / filename;
+    if (std::filesystem::exists(fullPath)) {
+        return fullPath.string();
     }
-    return false;
-}
-bool Plugin::RunningReplacementBgmMusic() {return _RunningReplacementBgmMusic;}
-bool Plugin::ShouldPauseReplacementBgmMusic() {
-    if (_ShouldPauseReplacementBgmMusic) {
-        _ShouldPauseReplacementBgmMusic = false;
-        _PausedReplacementBgmMusic = true;
-        return true;
+
+    filename = "bgm" + std::to_string(id) + ".mp3";
+    fullPath = _assetsFolderPath / "audio" / filename;
+    if (std::filesystem::exists(fullPath)) {
+        return fullPath.string();
     }
-    return false;
+
+    return "";
 }
-bool Plugin::ShouldUnpauseReplacementBgmMusic() {
-    if (_ShouldUnpauseReplacementBgmMusic) {
-        _ShouldUnpauseReplacementBgmMusic = false;
-        _PausedReplacementBgmMusic = false;
-        return true;
-    }
-    return false;
-}
-bool Plugin::ShouldStopReplacementBgmMusic() {
-    if (_ShouldStopReplacementBgmMusic) {
-        _ShouldStopReplacementBgmMusic = false;
-        return true;
-    }
-    return false;
-}
-u16 Plugin::CurrentBackgroundMusic() {return _CurrentBackgroundMusic;};
-u16 Plugin::BackgroundMusicToStop() {return _BackgroundMusicToStop;};
+
 
 void Plugin::onReplacementBackgroundMusicStarted() {
-    printf("Background music started\n");
+    //printf("Background music started\n");
     _ShouldStartReplacementBgmMusic = false;
-    _StartedReplacementBgmMusic = true;
-    _RunningReplacementBgmMusic = true;
+}
+
+bool Plugin::getShouldUpdateBackgroundMusicVolume() {
+    if (_ShouldUpdateReplacementBgmMusicVolume) {
+        _ShouldUpdateReplacementBgmMusicVolume = false;
+        return true;
+    }
+    return false;
 }
 
 bool Plugin::ShouldGrabMouseCursor() {

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -864,20 +864,6 @@ std::string Plugin::getReplacementBackgroundMusicFilePath(u16 id) {
     return "";
 }
 
-
-void Plugin::onReplacementBackgroundMusicStarted() {
-    //printf("Background music started\n");
-    _ShouldStartReplacementBgmMusic = false;
-}
-
-bool Plugin::getShouldUpdateBackgroundMusicVolume() {
-    if (_ShouldUpdateReplacementBgmMusicVolume) {
-        _ShouldUpdateReplacementBgmMusicVolume = false;
-        return true;
-    }
-    return false;
-}
-
 bool Plugin::ShouldGrabMouseCursor() {
     if (_ShouldGrabMouseCursor) {
         _ShouldGrabMouseCursor = false;

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -101,6 +101,14 @@ struct CutsceneEntry
     int dsScreensState;
 };
 
+struct BgmEntry
+{
+    u8 dsId = 0;
+    u8 loadingTableId = 0;
+    char DsName[16];
+    char Name[40];
+};
+
 enum EMidiState : u8 {
     Stopped = 0x00,
     LoadSequence  = 0x01,
@@ -187,10 +195,8 @@ public:
     static bool isCart(u32 gameCode) {return true;};
 
     void setNds(melonDS::NDS* Nds) {nds = Nds;};
-    virtual void onLoadROM() {};
-    virtual void onLoadState() {
-        texturesIndex.clear();
-    };
+    virtual void onLoadROM();
+    virtual void onLoadState();
 
     virtual std::string assetsFolder() {return std::to_string(GameCode);}
     std::filesystem::path assetsFolderPath();
@@ -290,7 +296,6 @@ public:
         return false;
     }
 
-    int delayBeforeStartReplacementBackgroundMusic();
     bool isBackgroundMusicPlaying() const { return _CurrentBackgroundMusic > 0; }
     u16 getCurrentBackgroundMusic() const { return _CurrentBackgroundMusic; }
     u16 getBackgroundMusicToStop() const { return _BackgroundMusicToStop; }
@@ -302,8 +307,20 @@ public:
 
     std::string getReplacementBackgroundMusicFilePath(u16 id);
 
-    virtual void refreshBackgroundMusic() {}
-    virtual std::string getBackgroundMusicName(u16 soundtrackId) const { return ""; }
+    virtual bool isBackgroundMusicReplacementImplemented() const { return false; }
+    virtual u16 getMidiBgmId() { return 0; }
+    virtual u16 getMidiBgmToResumeId() { return 0xFFFF; }
+    virtual u32 getMidiSongTableAddress() { return 0; }
+    virtual u8 getMidiBgmState() { return 0; }
+    virtual u8 getMidiBgmVolume() { return 0; }
+    virtual u16 getSongIdInSongTable(u16 bgmId) { return 0; }
+    virtual std::string getBackgroundMusicName(u16 soundtrackId) { return ""; }
+    virtual int delayBeforeStartReplacementBackgroundMusic() { return 0; }
+
+    void refreshBackgroundMusic();
+    std::string getBackgroundMusicName(u16 soundtrackId) const;
+    void muteSongSequence(u16 bgmId);
+    void stopBackgroundMusic(bool bImmediateStop);
 
     virtual void refreshMouseStatus() {}
 

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -266,27 +266,33 @@ public:
     void onReplacementCutsceneEnd();
     void onReturnToGameAfterCutscene();
 
-    enum EMusicRequest : u8 { Nothing, Start, Stop, Pause, Resume };
-    virtual EMusicRequest getMusicReplacementRequest() { return EMusicRequest::Nothing; }
-    bool getShouldUpdateBackgroundMusicVolume();
+    inline bool shouldStartBackgroundMusic() { return checkAndResetBool(_ShouldStartReplacementBgmMusic); }
+    inline bool shouldStopBackgroundMusic() { return checkAndResetBool(_ShouldStopReplacementBgmMusic); }
+    inline bool shouldPauseBackgroundMusic() { return checkAndResetBool(_ShouldPauseReplacementBgmMusic); _PausedReplacementBgmMusic = true; }
+    inline bool shouldResumeBackgroundMusic() { return checkAndResetBool(_ShouldUnpauseReplacementBgmMusic); _PausedReplacementBgmMusic = false; }
+    inline bool shouldUpdateBackgroundMusicVolume() { return checkAndResetBool(_ShouldUpdateReplacementBgmMusicVolume); }
+
+    inline bool checkAndResetBool(bool& val) {
+        if (val) {
+            val = false;
+            return true;
+        }
+        return false;
+    }
 
     int delayBeforeStartReplacementBackgroundMusic();
     bool isBackgroundMusicPlaying() const { return _CurrentBackgroundMusic > 0; }
     u16 getCurrentBackgroundMusic() const { return _CurrentBackgroundMusic; }
-    u16 getLastBackgroundMusic() const { return _LastBackgroundMusic; }
     u16 getBackgroundMusicToStop() const { return _BackgroundMusicToStop; }
     bool shouldForceStopMusic() const { return _ForceStopMusic; }
-    u16 getMusicFadeOutDuration() const { return _BackgroundMusicToStop; }
     u8 getCurrentBgmMusicVolume() const { return _BackgroundMusicVolume; }
     u32 getBgmDelayAtStart() const { return _BackgroundMusicDelayAtStart; }
+    bool getStoreBackgroundMusicPosition() const { return _StoreBackgroundMusicPosition; }
+    bool getResumeFromPositionBackgroundMusic() const { return _ResumeBackgroundMusicPosition; }
 
     std::string getReplacementBackgroundMusicFilePath(u16 id);
 
-    void onReplacementBackgroundMusicStarted();
-
     virtual void refreshBackgroundMusic() {}
-    virtual bool isBgmOfFieldType(u16 soundtrackId) const { return false; }
-    virtual bool isBgmOfBattleType(u16 soundtrackId) const { return false; }
     virtual std::string getBackgroundMusicName(u16 soundtrackId) const { return ""; }
 
     virtual void refreshMouseStatus() {}
@@ -393,7 +399,8 @@ protected:
     bool _ForceStopMusic = false;
     bool _MuteSeqBgm = false;
     u8 _BackgroundMusicVolume = 0x7f;
-
+    bool _StoreBackgroundMusicPosition = false;
+    bool _ResumeBackgroundMusicPosition = false;
 
     bool _ShouldGrabMouseCursor = false;
     bool _ShouldReleaseMouseCursor = false;

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -101,6 +101,15 @@ struct CutsceneEntry
     int dsScreensState;
 };
 
+enum EMidiState : u8 {
+    Stopped = 0x00,
+    LoadSequence  = 0x01,
+    PrePlay  = 0x02,
+    Playing = 0x03,
+    Stopping = 0x04
+};
+
+
 struct TextureEntryScene
 {
     std::string path;
@@ -161,6 +170,7 @@ struct TextureEntry
         return scenes[sceneIndex];
     }
 };
+
 
 class Plugin
 {
@@ -392,10 +402,9 @@ protected:
     bool _ShouldStopReplacementBgmMusic = false;
     bool _ShouldUpdateReplacementBgmMusicVolume = false;
     u16 _CurrentBackgroundMusic = 0;
-    u16 _LastBackgroundMusic = 0;
     u32 _BackgroundMusicDelayAtStart = 0;
-    u16 _LastSoundtrackId = 0;
     u16 _BackgroundMusicToStop = 0;
+    u8 _SoundtrackState = 0;
     bool _ForceStopMusic = false;
     bool _MuteSeqBgm = false;
     u8 _BackgroundMusicVolume = 0x7f;

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -266,24 +266,28 @@ public:
     void onReplacementCutsceneEnd();
     void onReturnToGameAfterCutscene();
 
+    enum EMusicRequest : u8 { Nothing, Start, Stop, Pause, Resume };
+    virtual EMusicRequest getMusicReplacementRequest() { return EMusicRequest::Nothing; }
+    bool getShouldUpdateBackgroundMusicVolume();
 
-    bool ShouldStartReplacementBgmMusic();
     int delayBeforeStartReplacementBackgroundMusic();
-    bool StartedReplacementBgmMusic();
-    bool RunningReplacementBgmMusic();
-    bool ShouldPauseReplacementBgmMusic();
-    bool ShouldUnpauseReplacementBgmMusic();
-    bool ShouldStopReplacementBgmMusic();
-    u16 CurrentBackgroundMusic();
-    u16 BackgroundMusicToStop();
+    bool isBackgroundMusicPlaying() const { return _CurrentBackgroundMusic > 0; }
+    u16 getCurrentBackgroundMusic() const { return _CurrentBackgroundMusic; }
+    u16 getLastBackgroundMusic() const { return _LastBackgroundMusic; }
+    u16 getBackgroundMusicToStop() const { return _BackgroundMusicToStop; }
+    bool shouldForceStopMusic() const { return _ForceStopMusic; }
+    u16 getMusicFadeOutDuration() const { return _BackgroundMusicToStop; }
+    u8 getCurrentBgmMusicVolume() const { return _BackgroundMusicVolume; }
+    u32 getBgmDelayAtStart() const { return _BackgroundMusicDelayAtStart; }
 
-    virtual std::string replacementBackgroundMusicFilePath(std::string name) {return "";}
+    std::string getReplacementBackgroundMusicFilePath(u16 id);
 
     void onReplacementBackgroundMusicStarted();
 
     virtual void refreshBackgroundMusic() {}
-    virtual bool shouldStoreBgmResumePosition(u16 soundtrackId) const { return false; }
-
+    virtual bool isBgmOfFieldType(u16 soundtrackId) const { return false; }
+    virtual bool isBgmOfBattleType(u16 soundtrackId) const { return false; }
+    virtual std::string getBackgroundMusicName(u16 soundtrackId) const { return ""; }
 
     virtual void refreshMouseStatus() {}
 
@@ -375,16 +379,20 @@ protected:
     CutsceneEntry* _LastCutscene = nullptr;
 
 
-    bool _StartedReplacementBgmMusic = false;
-    bool _RunningReplacementBgmMusic = false;
     bool _PausedReplacementBgmMusic = false;
     bool _ShouldPauseReplacementBgmMusic = false;
     bool _ShouldUnpauseReplacementBgmMusic = false;
     bool _ShouldStartReplacementBgmMusic = false;
     bool _ShouldStopReplacementBgmMusic = false;
+    bool _ShouldUpdateReplacementBgmMusicVolume = false;
     u16 _CurrentBackgroundMusic = 0;
+    u16 _LastBackgroundMusic = 0;
+    u32 _BackgroundMusicDelayAtStart = 0;
     u16 _LastSoundtrackId = 0;
     u16 _BackgroundMusicToStop = 0;
+    bool _ForceStopMusic = false;
+    bool _MuteSeqBgm = false;
+    u8 _BackgroundMusicVolume = 0x7f;
 
 
     bool _ShouldGrabMouseCursor = false;

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -296,7 +296,8 @@ public:
         return false;
     }
 
-    bool isBackgroundMusicPlaying() const { return _CurrentBackgroundMusic > 0; }
+    static u16 BGM_INVALID_ID;
+    bool isBackgroundMusicPlaying() const { return _CurrentBackgroundMusic != BGM_INVALID_ID; }
     u16 getCurrentBackgroundMusic() const { return _CurrentBackgroundMusic; }
     u16 getBackgroundMusicToStop() const { return _BackgroundMusicToStop; }
     bool shouldForceStopMusic() const { return _ForceStopMusic; }
@@ -309,7 +310,7 @@ public:
 
     virtual bool isBackgroundMusicReplacementImplemented() const { return false; }
     virtual u16 getMidiBgmId() { return 0; }
-    virtual u16 getMidiBgmToResumeId() { return 0xFFFF; }
+    virtual u16 getMidiBgmToResumeId() { return BGM_INVALID_ID; }
     virtual u32 getMidiSongTableAddress() { return 0; }
     virtual u8 getMidiBgmState() { return 0; }
     virtual u8 getMidiBgmVolume() { return 0; }
@@ -418,7 +419,7 @@ protected:
     bool _ShouldStartReplacementBgmMusic = false;
     bool _ShouldStopReplacementBgmMusic = false;
     bool _ShouldUpdateReplacementBgmMusicVolume = false;
-    u16 _CurrentBackgroundMusic = 0;
+    u16 _CurrentBackgroundMusic = BGM_INVALID_ID;
     u32 _BackgroundMusicDelayAtStart = 0;
     u16 _BackgroundMusicToStop = 0;
     u8 _SoundtrackState = 0;

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -129,10 +129,10 @@ u32 PluginKingdomHeartsDays::jpGamecode = 1246186329;
 #define SONG_ID_ADDRESS_JP      0x02190EBE
 #define SONG_ID_ADDRESS_JP_REV1 0x02190E3E
 
-#define SSEQ_TABLE_ADDRESS_US      0x020E51A0
-#define SSEQ_TABLE_ADDRESS_EU      0x020E5F80
-#define SSEQ_TABLE_ADDRESS_JP      0x020E4300
-#define SSEQ_TABLE_ADDRESS_JP_REV1 0x020E4280
+#define SSEQ_TABLE_ADDRESS_US      0x020E51B0
+#define SSEQ_TABLE_ADDRESS_EU      0x020E5F90
+#define SSEQ_TABLE_ADDRESS_JP      0x020E4310
+#define SSEQ_TABLE_ADDRESS_JP_REV1 0x020E4290
 
 #define INGAME_MENU_COMMAND_LIST_SETTING_ADDRESS_US      0x02194CC3
 #define INGAME_MENU_COMMAND_LIST_SETTING_ADDRESS_EU      0x02195AA3
@@ -269,6 +269,47 @@ PluginKingdomHeartsDays::PluginKingdomHeartsDays(u32 gameCode)
         {"847",    "847",    "847_roxas_leaves_the_organization", 0x0e9c2000, 0x0ec4c600, 0x0ec12c00, 0},
         {"848",    "848",    "848_xions_end",                     0x0eb91800, 0x0ee1be00, 0x0edf4600, 0},
     }};
+
+    BgmEntries = std::array<BgmEntry, 38> {{
+        { 1,  0,    "TwilightR_B",      "Sinister Sundown" },
+        { 2,  1,    "TwilightR_F",      "Lazy Afternoons" },
+        { 3,  2,    "DestinysForce",    "Destiny's Force" },
+        { 4,  3,    "Result",           "Results and Rewards" },
+        { 5,  4,    "Alice_F",          "Welcome to Wonderland" },
+        { 6,  5,    "Alice_B",          "To Our Surprise" },
+        { 7,  6,    "Herc_F",           "Olympus Coliseum" },
+        { 8,  7,    "Herc_B",           "Go for It!" },
+        { 9,  8,    "Halloween_F",      "This is Halloween" },
+        { 10, 9,    "Halloween_B",      "Spooks of Halloween Town" },
+        { 11, 10,   "Alasin_F",         "A Day in Agrabah" },
+        { 12, 11,   "Alasin_B",         "Arabian Dream" },
+        { 13, 12,   "Existence_F",      "Sacred Moon" },
+        { 14, 13,   "Existence_B",      "Critical Drive" },
+        { 15, 14,   "SacredMoon",       "Mystic Moon" },
+        { 16, 15,   "Beast_F",          "Waltz of the Damned" },
+        { 17, 16,   "Beast_B",          "Dance of the Daring" },
+        { 18, 17,   "ThemeXIII",        "Organization XIII" },
+        { 19, 18,   "ThemeRoxas",       "Roxas" },
+        { 20, 19,   "MissionBoss1",     "Tension Rising" },
+        { 21, 20,   "DisneyBoss1",      "Rowdy Rumble" },
+        { 22, 21,   "XIVtheme",         "Musique pour la tristesse de Xion" },
+        { 23, 22,   "ShorodingDark",    "Shrouding Dark Cloud" },
+        { 24, 23,   "Boss3",            "Vim and Vigor" },
+        { 25, 24,   "Riku",             "Riku" },
+        { 26, 25,   "StrangeWhispers",  "Strange Whispers" },
+        // note: no Song 27 in the DS IDs!
+        { 28, 26,   "ThemeOfFriends",   "Theme of Friends" },
+        { 29, 27,   "MissingYou",       "Missing You" },
+        { 30, 28,   "Resultsingle",     "Crossing the Finish Line" },
+        { 31, 29,   "Entrymulti",       "Cavern of Remembrance" },
+        { 32, 30,   "XIIItheme2",       "Xemnas" },
+        { 33, 31,   "Neverland_F",      "Secret of Neverland" },
+        { 34, 32,   "Neverland_B",      "Crossing to Neverland" },
+        { 35, 33,   "Icetime",          "At dusk I will think of you" },
+        { 36, 34,   "Boss4",            "Fight and Away" },
+        { 37, 35,   "RikuBattle",       "Another Side Battle Version" },
+        { 38, 36,   "Xionbattle",       "Vector to the Heavens" }
+    }};
 }
 
 void PluginKingdomHeartsDays::loadLocalization() {
@@ -379,24 +420,19 @@ void PluginKingdomHeartsDays::loadLocalization() {
 }
 
 void PluginKingdomHeartsDays::onLoadROM() {
-    stopBackgroundMusic(true);
-    _SoundtrackState = EMidiState::Stopped;
+    Plugin::onLoadROM();
 
     loadLocalization();
 
     u8* rom = (u8*)nds->GetNDSCart()->GetROM();
 }
 
-void PluginKingdomHeartsDays::onLoadState()
-{
-    texturesIndex.clear();
+void PluginKingdomHeartsDays::onLoadState() {
+    Plugin::onLoadState();
 
     loadLocalization();
 
     GameScene = gameScene_InGameWithMap;
-
-    stopBackgroundMusic(true);
-    _SoundtrackState = EMidiState::Stopped;
 }
 
 std::string PluginKingdomHeartsDays::assetsFolder() {
@@ -2094,199 +2130,35 @@ u16 PluginKingdomHeartsDays::getMidiBgmToResumeId() {
     return nds->ARM7Read8(SONG_SECOND_SLOT_ADDRESS);
 }
 
+u32 PluginKingdomHeartsDays::getMidiSongTableAddress() {
+    return getAnyByCart(SSEQ_TABLE_ADDRESS_US, SSEQ_TABLE_ADDRESS_EU, SSEQ_TABLE_ADDRESS_JP, SSEQ_TABLE_ADDRESS_JP_REV1);
+}
+
 u8 PluginKingdomHeartsDays::getMidiBgmVolume() {
     u32 SONG_MASTER_VOLUME_ADDRESS = getAnyByCart(SONG_ID_ADDRESS_US, SONG_ID_ADDRESS_EU, SONG_ID_ADDRESS_JP, SONG_ID_ADDRESS_JP_REV1) + 0x07;
     // Usually 0x7F during gameplay and 0x40 when game is paused
     return nds->ARM7Read8(SONG_MASTER_VOLUME_ADDRESS);
 }
 
-void PluginKingdomHeartsDays::muteSongSequence(u16 bgmId) {
 
-    if (bgmId == 0 || bgmId == 0xFFFF) {
-        return;
+u16 PluginKingdomHeartsDays::getSongIdInSongTable(u16 bgmId) {
+    auto found = std::find_if(BgmEntries.begin(), BgmEntries.end(), [&bgmId](const auto& e) {
+        return e.dsId == bgmId; });
+    if(found != BgmEntries.end()) {
+        return found->loadingTableId;
     }
 
-    // The game stores a table of entries in RAM, containing addresses of where the SSEQ is loaded
-    // The table's length is equal to the total number of tracks.
-    // Only one SSEQ is loaded at all times! And its address can be found using the BgmId (from SONG_ID_ADDRESS)
-    // Important: the EMidiState needs to be checked! When the status is "LoadSequence", the SSEQ is not loaded yet.
-    // When "PrePlay" or "Playing", the SSEQ is in RAM and its address is available.
-    // First u32 in a table row corresponds to the size of the loaded SSEQ, and the second u32 is the address in RAM.
-    // Caution: in Days, there is no track 27! Meaning that every song starting from 28 needs to be "-1" to get the correct address
-    // (otherwise you'll just get a nullptr entry in the table). See call to getSongIdInSongTable().
-    const u32 songTableAddr = getAnyByCart(SSEQ_TABLE_ADDRESS_US, SSEQ_TABLE_ADDRESS_EU, SSEQ_TABLE_ADDRESS_JP, SSEQ_TABLE_ADDRESS_JP_REV1);
-
-    u32 idInTable = getSongIdInSongTable(bgmId);
-    const u32 entryAddress = songTableAddr + (idInTable * 16);
-
-    u32 songSize = nds->ARM9Read32(entryAddress);
-    u32 songAddress = nds->ARM9Read32(entryAddress + 4);
-    if (songAddress == 0) {
-        return;
-    }
-
-    u32 sseqTag = nds->ARM9Read32(songAddress);
-    u32 sseqMagic = nds->ARM9Read32(songAddress + 4);
-    u32 sseqFileSize = nds->ARM9Read32(songAddress + 8);
-
-    if (sseqTag != 0x51455353) { // SSEQ
-        printf("Error: Invalid SSEQ: incorrect header tag\n");
-        return;
-    }
-
-    if (sseqMagic != 0x0100feff) {
-        printf("Error: Invalid SSEQ: incorrect magic number\n");
-        return;
-    }
-
-    if (sseqFileSize != songSize) {
-        printf("Error: Invalid SSEQ: incorrect file size\n");
-        return;
-    }
-
-    u32 firstValue = nds->ARM9Read32(songAddress + 32);
-    if (firstValue != 0) {
-        constexpr const u32 headerSize = 32;
-        u32 sizeToErase = songSize - headerSize;
-
-        u32 startErase = songAddress + headerSize;
-        u32 endErase = songAddress + songSize;
-        for (u32 addr = startErase; addr < endErase; addr+=4) {
-            nds->ARM7Write32(addr, 0x00);
-        }
-
-        //printf("Music SSEQ: Muted bgm %d (erased %d bytes)\n", bgmId, endErase - startErase);
-    }
+    return 0;
 }
 
-void PluginKingdomHeartsDays::stopBackgroundMusic(bool bImmediateStop) {
-    if (_CurrentBackgroundMusic > 0) {
-        u16 resumeSlot = getMidiBgmToResumeId();
-        _StoreBackgroundMusicPosition = (resumeSlot == _CurrentBackgroundMusic);
-        _ShouldStopReplacementBgmMusic = true;
-        _BackgroundMusicToStop = _CurrentBackgroundMusic;
-        _ForceStopMusic = bImmediateStop;
-        _CurrentBackgroundMusic = 0;
-    }
-    _MuteSeqBgm = false;
-}
-
-void PluginKingdomHeartsDays::refreshBackgroundMusic() {
-#if !REPLACEMENT_BGM_ENABLED
-    return;
-#endif
-
-    u16 bgmId = getMidiBgmId();
-    u8 state = getMidiBgmState();
-
-    if (state != _SoundtrackState) {
-        switch(state) {
-        case EMidiState::Stopped: {
-            break;
-        }
-        case EMidiState::LoadSequence: {
-            // Do nothing (used by the NDS to load the SSEQ MIDI into RAM)
-            break;
-        }
-        case EMidiState::PrePlay:
-        case EMidiState::Playing: {
-            // SSEQ is loaded and ready to play
-            if (bgmId != _CurrentBackgroundMusic) {
-                // Previous bgm should have already been stopped, but just in case:
-                stopBackgroundMusic(false);
-
-                std::string replacementBgmPath = getReplacementBackgroundMusicFilePath(bgmId);
-                if (replacementBgmPath != "") {
-                    _ShouldStartReplacementBgmMusic = true;
-                    _CurrentBackgroundMusic = bgmId;
-                    u16 bgmResumeId = getMidiBgmToResumeId();
-                    _ResumeBackgroundMusicPosition = (bgmResumeId == _CurrentBackgroundMusic);
-                    _BackgroundMusicDelayAtStart = delayBeforeStartReplacementBackgroundMusic();
-                    _MuteSeqBgm = true;
-                } else {
-                    _CurrentBackgroundMusic = 0;
-                }
-            }
-            break;
-            // TODO: handle difference between PrePlay and Play. Some songs are kept in "PrePlay" state (like Paused)
-            // This cannot be implement just yet because when playing HD cutscenes, the game clock's speed is increased
-            // And the switch to "Playing" happens way too early
-        }
-        case EMidiState::Stopping: {
-            // Note: bgmId is already 0xFFFF at this point
-            stopBackgroundMusic(false);
-            break;
-        }
-        default: {
-            break;
-        }
-        }
-        _SoundtrackState = state;
+std::string PluginKingdomHeartsDays::getBackgroundMusicName(u16 bgmId) {
+    auto found = std::find_if(BgmEntries.begin(), BgmEntries.end(), [&bgmId](const auto& e) {
+        return e.dsId == bgmId; });
+    if(found != BgmEntries.end()) {
+        return found->Name;
     }
 
-    u8 currVolume = getMidiBgmVolume();
-    if (_BackgroundMusicVolume != currVolume) {
-        _BackgroundMusicVolume = currVolume;
-        _ShouldUpdateReplacementBgmMusicVolume = true;
-    }
-
-    if (_MuteSeqBgm) {
-        muteSongSequence(bgmId);
-    }
-}
-
-std::string PluginKingdomHeartsDays::getBackgroundMusicName(u16 soundtrackId) const
-{
-    switch(soundtrackId)
-    {
-        case 1 : return "Sinister Sundown";
-        case 2 : return "Lazy Afternoons";
-        case 3 : return "Destiny's Force";
-        case 4 : return "Results and Rewards";
-        case 5 : return "Welcome to Wonderland";
-        case 6 : return "To Our Surprise";
-        case 7 : return "Olympus Coliseum";
-        case 8 : return "Go for It!";
-        case 9 : return "This is Halloween";
-        case 10 : return "Spooks of Halloween Town";
-        case 11 : return "A Day in Agrabah";
-        case 12 : return "Arabian Dream";
-        case 13 : return "Sacred Moon";
-        case 14 : return "Critical Drive";
-        case 15 : return "Mystic Moon";
-        case 16 : return "Waltz of the Damned";
-        case 17 : return "Dance of the Daring";
-        case 18 : return "Organization XIII";
-        case 19 : return "Roxas";
-        case 20 : return "Tension Rising";
-        case 21 : return "Rowdy Rumble";
-        case 22 : return "Musique pour la tristesse de Xion";
-        case 23 : return "Shrouding Dark Cloud";
-        case 24 : return "Vim and Vigor";
-        case 25 : return "Riku";
-        case 26 : return "Strange Whispers";
-        // no Id 27! gap needs to be removed when calling getSongIdInSongTable
-        case 28 : return "Theme of Friends";
-        case 29 : return "Missing You";
-        case 30 : return "Crossing the Finish Line";
-        case 31 : return "Cavern of Remembrance";
-        case 32 : return "Xemnas";
-        case 33 : return "Secret of Neverland";
-        case 34 : return "Crossing to Neverland";
-        case 35 : return "At dusk I will think of you";
-        case 36 : return "Fight and Away";
-        case 37 : return "Another Side Battle Version";
-        case 38 : return "Vector to the Heavens";
-        default: return "Unknown BGM";
-    }
-}
-
-u16 PluginKingdomHeartsDays::getSongIdInSongTable(u16 bgmId)
-{
-    if (bgmId > 0 && bgmId < 28)
-        return bgmId;
-    else
-        return bgmId - 1;
+    return 0;
 }
 
 int PluginKingdomHeartsDays::delayBeforeStartReplacementBackgroundMusic() {

--- a/src/plugins/PluginKingdomHeartsDays.h
+++ b/src/plugins/PluginKingdomHeartsDays.h
@@ -135,11 +135,12 @@ private:
     bool didMobiCutsceneEnded();
     bool canReturnToGameAfterReplacementCutscene();
 
-    u16 detectMidiBackgroundMusic();
+    u16 getMidiBgmId();
+    u16 getMidiBgmToResumeId();
+    u8 getMidiBgmState();
+    u8 getMidiBgmVolume();
 
     void refreshBackgroundMusic() override;
-    bool isBgmOfFieldType(u16 soundtrackId) const;
-    bool isBgmOfBattleType(u16 soundtrackId) const;
     std::string getBackgroundMusicName(u16 soundtrackId) const override;
     void muteSongSequence(u16 bgmId);
     u16 getSongIdInSongTable(u16 bgmId);

--- a/src/plugins/PluginKingdomHeartsDays.h
+++ b/src/plugins/PluginKingdomHeartsDays.h
@@ -62,7 +62,6 @@ public:
     bool isUnskippableMobiCutscene(CutsceneEntry* cutscene);
 
     int delayBeforeStartReplacementBackgroundMusic();
-    std::string replacementBackgroundMusicFilePath(std::string name);
 
     const char* getGameSceneName();
 
@@ -136,9 +135,16 @@ private:
     bool didMobiCutsceneEnded();
     bool canReturnToGameAfterReplacementCutscene();
 
+    EMusicRequest getMusicReplacementRequest() override;
+
     u16 detectMidiBackgroundMusic();
     void refreshBackgroundMusic() override;
-    bool shouldStoreBgmResumePosition(u16 soundtrackId) const override;
+    bool isBgmOfFieldType(u16 soundtrackId) const override;
+    bool isBgmOfBattleType(u16 soundtrackId) const override;
+    std::string getBackgroundMusicName(u16 soundtrackId) const override;
+    void muteSongSequence(u16 bgmId);
+    u16 getSongIdInSongTable(u16 bgmId);
+    void stopBackgroundMusic(bool bImmediateStop);
 
     void refreshMouseStatus();
 

--- a/src/plugins/PluginKingdomHeartsDays.h
+++ b/src/plugins/PluginKingdomHeartsDays.h
@@ -135,12 +135,11 @@ private:
     bool didMobiCutsceneEnded();
     bool canReturnToGameAfterReplacementCutscene();
 
-    EMusicRequest getMusicReplacementRequest() override;
-
     u16 detectMidiBackgroundMusic();
+
     void refreshBackgroundMusic() override;
-    bool isBgmOfFieldType(u16 soundtrackId) const override;
-    bool isBgmOfBattleType(u16 soundtrackId) const override;
+    bool isBgmOfFieldType(u16 soundtrackId) const;
+    bool isBgmOfBattleType(u16 soundtrackId) const;
     std::string getBackgroundMusicName(u16 soundtrackId) const override;
     void muteSongSequence(u16 bgmId);
     u16 getSongIdInSongTable(u16 bgmId);

--- a/src/plugins/PluginKingdomHeartsDays.h
+++ b/src/plugins/PluginKingdomHeartsDays.h
@@ -27,8 +27,8 @@ public:
     bool isJapanCartRev1() { return GameCode == jpGamecode && nds != nullptr && nds->GetNDSCart() != nullptr && nds->GetNDSCart()->GetROM()[0x1E] == 1; };
 
     void loadLocalization();
-    void onLoadROM();
-    void onLoadState();
+    void onLoadROM() override;
+    void onLoadState() override;
 
     std::string assetsFolder();
     std::string assetsRegionSubfolder();
@@ -60,8 +60,6 @@ public:
     std::string localizationFilePath(std::string language);
     std::filesystem::path patchReplacementCutsceneIfNeeded(CutsceneEntry* cutscene, std::filesystem::path folderPath);
     bool isUnskippableMobiCutscene(CutsceneEntry* cutscene);
-
-    int delayBeforeStartReplacementBackgroundMusic();
 
     const char* getGameSceneName();
 
@@ -135,16 +133,19 @@ private:
     bool didMobiCutsceneEnded();
     bool canReturnToGameAfterReplacementCutscene();
 
-    u16 getMidiBgmId();
-    u16 getMidiBgmToResumeId();
-    u8 getMidiBgmState();
-    u8 getMidiBgmVolume();
+    // Music replacement system
+    std::array<BgmEntry, 38> BgmEntries;
 
-    void refreshBackgroundMusic() override;
-    std::string getBackgroundMusicName(u16 soundtrackId) const override;
-    void muteSongSequence(u16 bgmId);
-    u16 getSongIdInSongTable(u16 bgmId);
-    void stopBackgroundMusic(bool bImmediateStop);
+    bool isBackgroundMusicReplacementImplemented() const override { return true; }
+    u16 getMidiBgmId() override;
+    u16 getMidiBgmToResumeId() override;
+    u32 getMidiSongTableAddress() override;
+    u8 getMidiBgmState() override;
+    u8 getMidiBgmVolume() override;
+    u16 getSongIdInSongTable(u16 bgmId) override;
+    std::string getBackgroundMusicName(u16 bgmId) override;
+    int delayBeforeStartReplacementBackgroundMusic() override;
+
 
     void refreshMouseStatus();
 

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -2322,23 +2322,6 @@ bool PluginKingdomHeartsReCoded::isUnskippableMobiCutscene(CutsceneEntry* cutsce
     // return isSaveLoaded() && strcmp(cutscene->DsName, "843") == 0;
 }
 
-std::string PluginKingdomHeartsReCoded::replacementBackgroundMusicFilePath(std::string name) {
-    std::string filename = name + ".wav";
-    std::filesystem::path _assetsFolderPath = assetsFolderPath();
-    std::filesystem::path fullPath = _assetsFolderPath / "audio" / filename;
-    if (std::filesystem::exists(fullPath)) {
-        return fullPath.string();
-    }
-
-    filename = name + ".mp3";
-    fullPath = _assetsFolderPath / "audio" / filename;
-    if (std::filesystem::exists(fullPath)) {
-        return fullPath.string();
-    }
-
-    return "";
-}
-
 std::string PluginKingdomHeartsReCoded::localizationFilePath(std::string language) {
     std::string filename = language + ".ini";
     std::filesystem::path _assetsFolderPath = assetsFolderPath();

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -126,12 +126,12 @@ u32 PluginKingdomHeartsReCoded::jpGamecode = 1245268802;
 #define DIALOG_SCREEN_VALUE_JP 0x00000000 // TODO: KH probably correct, but didn't check
 
 #define SONG_ID_ADDRESS_US      0x02192012
-#define SONG_ID_ADDRESS_EU      0x02192012 // TODO: KH wrong
-#define SONG_ID_ADDRESS_JP      0x02192012 // TODO: KH wrong
+#define SONG_ID_ADDRESS_EU      0x02192EB2
+#define SONG_ID_ADDRESS_JP      0x02190CB2
 
 #define SSEQ_TABLE_ADDRESS_US      0x020E1E70
-#define SSEQ_TABLE_ADDRESS_EU      0x020E1E70 // TODO: KH wrong
-#define SSEQ_TABLE_ADDRESS_JP      0x020E1E70 // TODO: KH wrong
+#define SSEQ_TABLE_ADDRESS_EU      0x020E2D10
+#define SSEQ_TABLE_ADDRESS_JP      0x020E0B10
 
 
 #define SWITCH_TARGET_PRESS_FRAME_LIMIT   100

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -1493,8 +1493,9 @@ bool PluginKingdomHeartsReCoded::renderer_showOriginalUI() {
     return false;
 }
 
-void PluginKingdomHeartsReCoded::onLoadState()
-{
+void PluginKingdomHeartsReCoded::onLoadState() {
+    Plugin::onLoadState();
+
     texturesIndex.clear();
 
     loadLocalization();

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -125,6 +125,15 @@ u32 PluginKingdomHeartsReCoded::jpGamecode = 1245268802;
 #define DIALOG_SCREEN_VALUE_EU 0x00000000
 #define DIALOG_SCREEN_VALUE_JP 0x00000000 // TODO: KH probably correct, but didn't check
 
+#define SONG_ID_ADDRESS_US      0x02192012
+#define SONG_ID_ADDRESS_EU      0x02192012 // TODO: KH wrong
+#define SONG_ID_ADDRESS_JP      0x02192012 // TODO: KH wrong
+
+#define SSEQ_TABLE_ADDRESS_US      0x020E1E70
+#define SSEQ_TABLE_ADDRESS_EU      0x020E1E70 // TODO: KH wrong
+#define SSEQ_TABLE_ADDRESS_JP      0x020E1E70 // TODO: KH wrong
+
+
 #define SWITCH_TARGET_PRESS_FRAME_LIMIT   100
 #define SWITCH_TARGET_TIME_BETWEEN_SWITCH 20
 #define LOCK_ON_PRESS_FRAME_LIMIT         100
@@ -256,6 +265,50 @@ PluginKingdomHeartsReCoded::PluginKingdomHeartsReCoded(u32 gameCode)
         {"w8_ED3", "576_PLUS_mm", "576_",                       0x0c216800, 0x0c27ec00, 0x0c12cc00, 2},
         {"w8_OP",  "573_PLUS_mm", "573_",                       0x0c426000, 0x0c48e400, 0x0c33c400, 2},
     }};
+
+    BgmEntries = std::array<BgmEntry, 41> {{
+        { 0,  0,    "WorldSelect", "" },
+        { 1,  1,    "Avatar", "" },
+        { 2,  2,    "ShroudingDark", "" },
+        { 3,  3,    "Dest_F", "" },
+        { 4,  4,    "Night_B", "" },
+        { 5,  5,    "Destati", "" },
+        { 6,  6,    "StrangeWhispers", "" },
+        { 7,  7,    "Andante", "" },
+        { 8,  8,    "Ttown_F", "" },
+        { 9,  9,    "Alice_F", "" },
+        { 10, 10,   "Alice_B", "" },
+        { 11, 11,   "Herc_F", "" },
+        { 12, 12,   "Herc_F2", "" },
+        { 13, 13,   "Herc_B", "" },
+        { 14, 14,   "Aladdin_F", "" },
+        { 15, 15,   "Aladdin_B", "" },
+        { 16, 16,   "Hollow_F", "" },
+        { 17, 17,   "Hollow_B", "" },
+        { 18, 18,   "Hollow_B2", "" },
+        { 19, 19,   "Castle_F", "" },
+        { 20, 20,   "Castle_B", "" },
+        { 21, 21,   "Namine", "" },
+        { 22, 22,   "Sysnormal_F", "" },
+        { 23, 23,   "Sysnormal_B", "" },
+        { 24, 24,   "Sysbug_F", "" },
+        { 25, 25,   "Sysbug_B", "" },
+        { 26, 26,   "Ability", "" },
+        { 27, 27,   "Destiny_B", "" },
+        { 28, 28,   "Roxas_B", "" },
+        { 29, 29,   "Missionboss1_B", "" },
+        { 30, 30,   "DisneyBoss1_B", "" },
+        { 31, 31,   "Boss3_B", "" },
+        { 32, 32,   "Boss4_B", "" },
+        { 33, 33,   "End_B", "" },
+        { 34, 34,   "Villains", "" },
+        { 35, 35,   "Riku", "" },
+        { 36, 36,   "Laughter", "" },
+        { 37, 37,   "Courage", "" },
+        { 38, 38,   "LastBoss", "" },
+        { 39, 39,   "Debug", "" },
+        { 40, 40,   "Rik_BG", "" }
+    }};
 }
 
 void PluginKingdomHeartsReCoded::loadLocalization() {
@@ -366,6 +419,8 @@ void PluginKingdomHeartsReCoded::loadLocalization() {
 }
 
 void PluginKingdomHeartsReCoded::onLoadROM() {
+    Plugin::onLoadROM();
+    
     loadLocalization();
 
     u8* rom = (u8*)nds->GetNDSCart()->GetROM();
@@ -2449,6 +2504,53 @@ bool PluginKingdomHeartsReCoded::isSaveLoaded()
 {
     return getCurrentMap() != 0;
 }
+
+
+u16 PluginKingdomHeartsReCoded::getMidiBgmId() {
+    u16 soundtrack = nds->ARM7Read16(getU32ByCart(SONG_ID_ADDRESS_US, SONG_ID_ADDRESS_EU, SONG_ID_ADDRESS_JP));
+    if (soundtrack > 0) {
+        return soundtrack;
+    }
+    return 0;
+}
+
+u8 PluginKingdomHeartsReCoded::getMidiBgmState() {
+    u32 SONG_STATE_ADDRESS = getU32ByCart(SONG_ID_ADDRESS_US, SONG_ID_ADDRESS_EU, SONG_ID_ADDRESS_JP) + 0x04;
+    // See enum EMidiState for details of the state
+    return nds->ARM7Read8(SONG_STATE_ADDRESS);
+}
+
+u32 PluginKingdomHeartsReCoded::getMidiSongTableAddress() {
+    return getU32ByCart(SSEQ_TABLE_ADDRESS_US, SSEQ_TABLE_ADDRESS_EU, SSEQ_TABLE_ADDRESS_JP);
+}
+
+u8 PluginKingdomHeartsReCoded::getMidiBgmVolume() {
+    u32 SONG_MASTER_VOLUME_ADDRESS = getU32ByCart(SONG_ID_ADDRESS_US, SONG_ID_ADDRESS_EU, SONG_ID_ADDRESS_JP) + 0x05;
+    // Usually 0x7F during gameplay and 0x40 when game is paused
+    return nds->ARM7Read8(SONG_MASTER_VOLUME_ADDRESS);
+}
+
+
+u16 PluginKingdomHeartsReCoded::getSongIdInSongTable(u16 bgmId) {
+    auto found = std::find_if(BgmEntries.begin(), BgmEntries.end(), [&bgmId](const auto& e) {
+        return e.dsId == bgmId; });
+    if(found != BgmEntries.end()) {
+        return found->loadingTableId;
+    }
+
+    return 0;
+}
+
+std::string PluginKingdomHeartsReCoded::getBackgroundMusicName(u16 bgmId) {
+    auto found = std::find_if(BgmEntries.begin(), BgmEntries.end(), [&bgmId](const auto& e) {
+        return e.dsId == bgmId; });
+    if(found != BgmEntries.end()) {
+        return found->Name;
+    }
+
+    return 0;
+}
+
 
 void PluginKingdomHeartsReCoded::debugLogs(int gameScene)
 {

--- a/src/plugins/PluginKingdomHeartsReCoded.h
+++ b/src/plugins/PluginKingdomHeartsReCoded.h
@@ -41,7 +41,7 @@ public:
     void gpu3DOpenGLClassic_VS_Z_initVariables(GLuint prog, u32 flags);
     void gpu3DOpenGLClassic_VS_Z_updateVariables(GLuint CompShader, u32 flags);
 
-    void onLoadState();
+    void onLoadState() override;
 
     void applyHotkeyToInputMaskOrTouchControls(u32* InputMask, u16* touchX, u16* touchY, bool* isTouching, u32* HotkeyMask, u32* HotkeyPress);
     void applyAddonKeysToInputMaskOrTouchControls(u32* InputMask, u16* touchX, u16* touchY, bool* isTouching, u32* HotkeyMask, u32* HotkeyPress);

--- a/src/plugins/PluginKingdomHeartsReCoded.h
+++ b/src/plugins/PluginKingdomHeartsReCoded.h
@@ -56,8 +56,6 @@ public:
     std::filesystem::path patchReplacementCutsceneIfNeeded(CutsceneEntry* cutscene, std::filesystem::path folderPath);
     bool isUnskippableMobiCutscene(CutsceneEntry* cutscene);
 
-    std::string replacementBackgroundMusicFilePath(std::string name);
-
     const char* getGameSceneName();
 
     bool shouldRenderFrame();

--- a/src/plugins/PluginKingdomHeartsReCoded.h
+++ b/src/plugins/PluginKingdomHeartsReCoded.h
@@ -24,7 +24,7 @@ public:
     bool isJapanCart()  { return GameCode == jpGamecode; };
 
     void loadLocalization();
-    void onLoadROM();
+    void onLoadROM() override;
 
     std::string assetsFolder();
     std::string tomlUniqueIdentifier();
@@ -126,6 +126,17 @@ private:
     u32 getCurrentMainMenuView();
     u32 getCurrentMap();
     bool isSaveLoaded();
+
+    // Music replacement system
+    std::array<BgmEntry, 41> BgmEntries;
+
+    bool isBackgroundMusicReplacementImplemented() const override { return true; }
+    u16 getMidiBgmId() override;
+    u32 getMidiSongTableAddress() override;
+    u8 getMidiBgmState() override;
+    u8 getMidiBgmVolume() override;
+    u16 getSongIdInSongTable(u16 bgmId) override;
+    std::string getBackgroundMusicName(u16 bgmId) override;
 
     bool isBufferBlack(unsigned int* buffer);
     u32* topScreen2DTexture();


### PR DESCRIPTION
- fixed songs were sometimes playing from position when they shouldn't (now only resuming when "field" plays after "battle")
- fixed songs not stopping in cases where no music should play (when dying, withdrawing, during cutscenes, etc)
- now handling bgm muting by erasing the SSEQ in RAM instead of modifying the song ID (it was breaking stop requests)
- now lowering bgm volume when pausing or during cutscenes (original DS behaviour)
- better handling of fadein/fadeout/volume changes, smooth logarithmic transitions
- fixed delayed bgm play (post Xion fight cutscene), also handling cancelling of delay when skipping cutscene
- fixed bgm not stopping when loading state or when loading other rom
- proper handling of bgm "state" from RAM value: we now know exactly when a bgm is stopped/loading/playing/stopping
- bgm replacement now works in Re:Coded! moved code from Days plugin to Plugin.h to re-use between plugins
- retrieved all EU, US and JP bgm RAM addresses (for Days and Re:Coded)
- added list of all music songs (Days and Re:Coded) for better handling of song table ID and resume bgm ID