### PR TITLE
Bgm replacement bug fixes

### DIFF
--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -911,6 +911,10 @@ void Plugin::refreshBackgroundMusic() {
     if (state != _SoundtrackState) {
         switch(state) {
         case EMidiState::Stopped: {
+            if (_SoundtrackState == EMidiState::Playing
+                && _CurrentBackgroundMusic != BGM_INVALID_ID) {
+                stopBackgroundMusic(true);
+            }
             break;
         }
         case EMidiState::LoadSequence: {

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -971,7 +971,7 @@ void Plugin::refreshBackgroundMusic() {
 
 void Plugin::muteSongSequence(u16 bgmId) {
 
-    if (bgmId == 0 || bgmId == 0xFFFF) {
+    if (bgmId == 0xFFFF) {
         return;
     }
 

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -2160,7 +2160,7 @@ std::string PluginKingdomHeartsDays::getBackgroundMusicName(u16 bgmId) {
 int PluginKingdomHeartsDays::delayBeforeStartReplacementBackgroundMusic() {
     u32 currentMission = getCurrentMission();
     if (currentMission == 92 && _CurrentBackgroundMusic == 22) {
-        return 12500;
+        return 13000;
     }
     return 0;
 }

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -2110,11 +2110,7 @@ bool PluginKingdomHeartsDays::isUnskippableMobiCutscene(CutsceneEntry* cutscene)
 }
 
 u16 PluginKingdomHeartsDays::getMidiBgmId() {
-    u16 soundtrack = nds->ARM7Read16(getAnyByCart(SONG_ID_ADDRESS_US, SONG_ID_ADDRESS_EU, SONG_ID_ADDRESS_JP, SONG_ID_ADDRESS_JP_REV1));
-    if (soundtrack > 0) {
-        return soundtrack;
-    }
-    return 0;
+    return nds->ARM7Read16(getAnyByCart(SONG_ID_ADDRESS_US, SONG_ID_ADDRESS_EU, SONG_ID_ADDRESS_JP, SONG_ID_ADDRESS_JP_REV1));
 }
 
 u8 PluginKingdomHeartsDays::getMidiBgmState() {
@@ -2158,7 +2154,7 @@ std::string PluginKingdomHeartsDays::getBackgroundMusicName(u16 bgmId) {
         return found->Name;
     }
 
-    return 0;
+    return "Unknown";
 }
 
 int PluginKingdomHeartsDays::delayBeforeStartReplacementBackgroundMusic() {

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -2508,11 +2508,7 @@ bool PluginKingdomHeartsReCoded::isSaveLoaded()
 
 
 u16 PluginKingdomHeartsReCoded::getMidiBgmId() {
-    u16 soundtrack = nds->ARM7Read16(getU32ByCart(SONG_ID_ADDRESS_US, SONG_ID_ADDRESS_EU, SONG_ID_ADDRESS_JP));
-    if (soundtrack > 0) {
-        return soundtrack;
-    }
-    return 0;
+    return nds->ARM7Read16(getU32ByCart(SONG_ID_ADDRESS_US, SONG_ID_ADDRESS_EU, SONG_ID_ADDRESS_JP));
 }
 
 u8 PluginKingdomHeartsReCoded::getMidiBgmState() {
@@ -2549,7 +2545,7 @@ std::string PluginKingdomHeartsReCoded::getBackgroundMusicName(u16 bgmId) {
         return found->Name;
     }
 
-    return 0;
+    return "Unknown";
 }
 
 


### PR DESCRIPTION
- fixed bgm not muted when going from mission mode back to main menu (Days)
- fixed bgm delay duration for Xion post fight cutscene music
- fixed bgm n°0 (world map) wasn't muted (Re:Coded)