### PR TITLE
Bgm fadeout improvement, wav reuse system, streamed bgm replacement, misc fixes

### DIFF
--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -90,7 +90,7 @@ void EmuThread::attachWindow(MainWindow* window)
     }
 
     connect(this, SIGNAL(windowStartBgmMusic(quint16, quint8, bool, quint32, QString)), window, SLOT(asyncStartBgmMusic(quint16, quint8, bool, quint32, QString)));
-    connect(this, SIGNAL(windowStopBgmMusic(quint16, bool, bool)), window, SLOT(asyncStopBgmMusic(quint16, bool, bool)));
+    connect(this, SIGNAL(windowStopBgmMusic(quint16, bool, quint32)), window, SLOT(asyncStopBgmMusic(quint16, bool, quint32)));
     connect(this, SIGNAL(windowPauseBgmMusic()), window, SLOT(asyncPauseBgmMusic()));
     connect(this, SIGNAL(windowUnpauseBgmMusic()), window, SLOT(asyncUnpauseBgmMusic()));
     connect(this, SIGNAL(windowUpdateBgmMusicVolume(quint8)), window, SLOT(asyncUpdateBgmMusicVolume(quint8)));
@@ -120,7 +120,7 @@ void EmuThread::detachWindow(MainWindow* window)
     }
 
     disconnect(this, SIGNAL(windowStartBgmMusic(quint16, quint8, bool, quint32, QString)), window, SLOT(asyncStartBgmMusic(quint16, quint8, bool, quint32, QString)));
-    disconnect(this, SIGNAL(windowStopBgmMusic(quint16, bool, bool)), window, SLOT(asyncStopBgmMusic(quint16, bool, bool)));
+    disconnect(this, SIGNAL(windowStopBgmMusic(quint16, bool, quint32)), window, SLOT(asyncStopBgmMusic(quint16, bool, quint32)));
     disconnect(this, SIGNAL(windowPauseBgmMusic()), window, SLOT(asyncPauseBgmMusic()));
     disconnect(this, SIGNAL(windowUnpauseBgmMusic()), window, SLOT(asyncUnpauseBgmMusic()));
     disconnect(this, SIGNAL(windowUpdateBgmMusicVolume(quint8)), window, SLOT(asyncUpdateBgmMusicVolume(quint8)));
@@ -795,8 +795,8 @@ void EmuThread::refreshPluginState()
         if (plugin->shouldStopBackgroundMusic()) {
             u16 bgm = plugin->getBackgroundMusicToStop();
             bool bShouldStoreResumePos = plugin->getStoreBackgroundMusicPosition();
-            bool bShouldForceStopMusic = plugin->shouldForceStopMusic();
-            emit windowStopBgmMusic(bgm, bShouldStoreResumePos, bShouldForceStopMusic);
+            u32 fadeOutDuration = plugin->getBackgroundMusicFadeOutToApply();
+            emit windowStopBgmMusic(bgm, bShouldStoreResumePos, fadeOutDuration);
         }
 
         if (plugin->shouldPauseBackgroundMusic()) {

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -782,7 +782,7 @@ void EmuThread::refreshPluginState()
 
         if (plugin->shouldStartBackgroundMusic()) {
             u16 bgm = plugin->getCurrentBackgroundMusic();
-            std::string path = plugin->getReplacementBackgroundMusicFilePath(bgm);
+            const std::string& path = plugin->getCurrentBackgroundMusicFilePath();
 
             bool bShouldStoreResumePos = plugin->getResumeFromPositionBackgroundMusic();
             u8 volume = plugin->getCurrentBgmMusicVolume();

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -158,7 +158,7 @@ signals:
     void syncVolumeLevel();
 
     void windowStartBgmMusic(quint16 bgmId, quint8 volume, bool bStoreResumePos, quint32 delayAtStart, QString filePath);
-    void windowStopBgmMusic(quint16 bgmId, bool bStoreResumePos, bool bShouldForceStop);
+    void windowStopBgmMusic(quint16 bgmId, bool bStoreResumePos, quint32 fadeOutDuration);
     void windowPauseBgmMusic();
     void windowUnpauseBgmMusic();
     void windowUpdateBgmMusicVolume(quint8 volume);

--- a/src/frontend/qt_sdl/MainWindow/AudioPlayer.cpp
+++ b/src/frontend/qt_sdl/MainWindow/AudioPlayer.cpp
@@ -55,13 +55,7 @@ void AudioPlayer::stop(int fadeOutMs)
         return;
     }
 
-    if (fadeOutMs == 0) {
-        m_audioOutput->stop();
-        m_audioSource->onStopped();
-        m_playing = false;
-    } else {
-        m_audioSource->startFadeOut(fadeOutMs);
-    }
+    m_audioSource->startFadeOut(fadeOutMs);
 }
 
 qint64 AudioPlayer::getCurrentPlayingPos() const

--- a/src/frontend/qt_sdl/MainWindow/AudioSource.cpp
+++ b/src/frontend/qt_sdl/MainWindow/AudioSource.cpp
@@ -47,6 +47,7 @@ void AudioSourceWav::onStarted(qint64 resumePosition, qreal volume, int fadeInMs
     m_samplesRemaining = 0;
     m_totalTransitionSamples = 0;
     m_status = EStatus::Playing;
+    m_stoppingDelay = 0;
     volume = std::clamp(volume, 0.0, 1.0);
 
     m_currentPos = m_dataStart + resumePosition;
@@ -63,6 +64,7 @@ void AudioSourceWav::onStopped()
 {
     m_currentPos = m_dataStart;
     m_status = EStatus::Stopped;
+    m_stoppingDelay = 0;
 
     m_currentVolume = 0.0;
     m_samplesRemaining = 0;
@@ -114,12 +116,16 @@ qint64 AudioSourceWav::readData(char *data, qint64 maxSize)
 
     m_currentPos = m_file.pos();
 
-    applyVolume(data, bytesRead);
-
     if (m_samplesRemaining <= 0 && m_status == EStatus::Stopping) {
-        QMetaObject::invokeMethod(parent(), "onFadeOutCompleted", Qt::QueuedConnection);
-        m_status = EStatus::Stopped;
+        if (m_stoppingDelay > 0) {
+            m_stoppingDelay -= maxSize;
+        } else {
+            QMetaObject::invokeMethod(parent(), "onFadeOutCompleted", Qt::QueuedConnection);
+            m_status = EStatus::Stopped;
+        }
     }
+
+    applyVolume(data, bytesRead);
 
     return bytesRead;
 }
@@ -133,6 +139,7 @@ void AudioSourceWav::startFadeOut(int durationMs)
 {
     setVolume(0.0, durationMs);
     m_status = EStatus::Stopping;
+    m_stoppingDelay = m_sampleRate; // 1 sec delay before destroying source
 }
 
 void AudioSourceWav::applyVolume(char* buffer, int64_t numBytes)
@@ -146,18 +153,6 @@ void AudioSourceWav::applyVolume(char* buffer, int64_t numBytes)
     while (remainingBytes > 0)
     {
         float gain = m_currentVolume;
-        if (m_samplesRemaining > 0) {
-            float position = ((m_totalTransitionSamples - m_samplesRemaining) / (float)m_totalTransitionSamples);
-
-            if (m_targetVolume <= 0.0f) {
-                gain = m_currentVolume * std::exp(-6.0f * position);
-            } else {
-                float dbCurrent = 20.0f * std::log10(m_currentVolume);
-                float dbTarget = 20.0f * std::log10(targetForCalculation);
-                float dbCurrent_i = dbCurrent + position * (dbTarget - dbCurrent);
-                gain = std::pow(10.0f, dbCurrent_i / 20.0f);
-            }
-        }
 
         if (m_bitsPerSample == 16) {
             int16_t value = (static_cast<uint8_t>(samplePtr[0])) |

--- a/src/frontend/qt_sdl/MainWindow/AudioSource.cpp
+++ b/src/frontend/qt_sdl/MainWindow/AudioSource.cpp
@@ -235,7 +235,7 @@ QAudioFormat::SampleFormat AudioSourceWav::bitsPerSampleToSampleFormat(quint16 b
     {
         case 8: return QAudioFormat::UInt8;
         case 16: return QAudioFormat::Int16;
-        case 24: return QAudioFormat::Int32;
+        //case 24: return QAudioFormat::Int32; // Unhandled
         case 32: return QAudioFormat::Int32;
         default: return QAudioFormat::Unknown; // Unhandled
     }
@@ -277,9 +277,10 @@ bool AudioSourceWav::readWavHeader()
             m_format.setChannelCount(m_numChannels);
             
             auto sampleFormat = bitsPerSampleToSampleFormat(m_bitsPerSample);
-            m_format.setSampleFormat(sampleFormat);
-
-            foundFormat = true;
+            if (sampleFormat != QAudioFormat::Unknown) {
+                m_format.setSampleFormat(sampleFormat);
+                foundFormat = true;
+            }
         } else if (memcmp(chunkId, "data", 4) == 0) {
             m_dataStart = m_file.pos();
             m_currentPos = m_dataStart;

--- a/src/frontend/qt_sdl/MainWindow/AudioSource.h
+++ b/src/frontend/qt_sdl/MainWindow/AudioSource.h
@@ -64,6 +64,7 @@ private:
 
     enum class EStatus : quint8 { Playing, Stopping, Stopped };
     EStatus m_status = EStatus::Stopped;
+    quint64 m_stoppingDelay = 0;
 
     double m_currentVolume = 1.0;
     double m_targetVolume = 1.0;

--- a/src/frontend/qt_sdl/MainWindow/MainWindowSettings.cpp
+++ b/src/frontend/qt_sdl/MainWindow/MainWindowSettings.cpp
@@ -143,22 +143,20 @@ qreal MainWindowSettings::getBgmMusicVolume(quint8 ramVolume)
     return (volume / 256.0);
 }
 
-void MainWindowSettings::asyncStopBgmMusic(quint16 bgmId, bool bStoreResumePos, bool bShouldForceStop)
+void MainWindowSettings::asyncStopBgmMusic(quint16 bgmId, bool bStoreResumePos, quint32 fadeOutDuration)
 {
-    QMetaObject::invokeMethod(this, "stopBgmMusic", Qt::QueuedConnection, Q_ARG(quint16, bgmId), Q_ARG(bool, bStoreResumePos), Q_ARG(bool, bShouldForceStop));
+    QMetaObject::invokeMethod(this, "stopBgmMusic", Qt::QueuedConnection, Q_ARG(quint16, bgmId), Q_ARG(bool, bStoreResumePos), Q_ARG(quint32, fadeOutDuration));
 }
 
-void MainWindowSettings::stopBgmMusic(quint16 bgmId, bool bStoreResumePos, bool bShouldForceStop)
+void MainWindowSettings::stopBgmMusic(quint16 bgmId, bool bStoreResumePos, quint32 fadeOutDuration)
 {
     if (delayedBgmStart)
         delayedBgmStart.reset();
 
     for(auto* player : bgmPlayers) {
         if (player->getBgmId() == bgmId && player->isPlaying()) {
-            static constexpr int kFadeOutDurationMs = 1800;
-            int fadeOut = bShouldForceStop ? 0 : kFadeOutDurationMs;
-            printf("Stopping replacement song %d with %dms fadeout\n", bgmId, fadeOut);
-            player->stop(fadeOut);
+            printf("Stopping replacement song %d with %dms fadeout\n", bgmId, fadeOutDuration);
+            player->stop(fadeOutDuration);
 
             if (bStoreResumePos) {
                 bgmToResumeId = bgmId;

--- a/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
+++ b/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
@@ -48,14 +48,14 @@ public:
 
 public slots:
     void asyncStartBgmMusic(quint16 bgmId, quint8 volume, bool bResumePos, quint32 delayAtStart, QString bgmMusicFilePath);
-    void asyncStopBgmMusic(quint16 bgmId, bool bStoreResumePos, bool bShouldForceStop);
+    void asyncStopBgmMusic(quint16 bgmId, bool bStoreResumePos, quint32 fadeOutDuration);
     void asyncPauseBgmMusic();
     void asyncUnpauseBgmMusic();
     void asyncUpdateBgmMusicVolume(quint8 ramVolume);
     void asyncStopAllBgm();
 
     void startBgmMusic(quint16 bgmId, quint8 volume, bool bResumePos, QString bgmMusicFilePath);
-    void stopBgmMusic(quint16 bgmId, bool bStoreResumePos, bool bShouldForceStop);
+    void stopBgmMusic(quint16 bgmId, bool bStoreResumePos, quint32 fadeOutDuration);
     void pauseBgmMusic();
     void unpauseBgmMusic();
     void stopAllBgm();

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -1059,7 +1059,8 @@ void Plugin::refreshStreamedMusic() {
         bStopAndReturn = true;
     }
 
-    u16 streamBgmId = getStreamBgmIdFromAddress(strmHeaderAddress);
+    u32 numSamples = nds->ARM9Read32(strmHeaderAddress + 0x24);
+    u16 streamBgmId = getStreamBgmIdFromAddress(strmHeaderAddress, numSamples);
     if (streamBgmId == BGM_INVALID_ID) {
         bStopAndReturn = true;
     }

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstdarg>
 #include <cstdio>
+#include <fstream>
 
 #ifdef __APPLE__
 #include <objc/objc.h>
@@ -865,10 +866,18 @@ std::string Plugin::getReplacementBackgroundMusicFilePath(u16 id) {
         return fullPath.string();
     }
 
-    filename = "bgm" + std::to_string(id) + ".mp3";
+    // File redirector (.txt file should only contain the filename, not the fullpath, example: "bgm4.wav")
+    filename = "bgm" + std::to_string(id) + ".txt";
     fullPath = _assetsFolderPath / "audio" / filename;
     if (std::filesystem::exists(fullPath)) {
-        return fullPath.string();
+
+        std::ifstream ifs(fullPath);
+        std::string redirector((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+
+        std::filesystem::path redirector_fullpath = fullPath = _assetsFolderPath / "audio" / redirector;
+        if (std::filesystem::exists(redirector_fullpath)) {
+            return redirector_fullpath.string();
+        }
     }
 
     return "";

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -334,6 +334,7 @@ public:
     virtual std::string getBackgroundMusicName(u16 soundtrackId) { return ""; }
     virtual int delayBeforeStartReplacementBackgroundMusic() { return 0; }
 
+    void loadBgmRedirections();
     void refreshBackgroundMusic();
     std::string getBackgroundMusicName(u16 soundtrackId) const;
     void muteSongSequence(u16 bgmId);
@@ -447,6 +448,7 @@ protected:
     u8 _BackgroundMusicVolume = 0x7f;
     bool _StoreBackgroundMusicPosition = false;
     bool _ResumeBackgroundMusicPosition = false;
+    std::map<std::string, std::string> _BgmRedirectors;
 
     u32 _CurrentStreamAddress = 0;
     bool _CurrentBgmIsStream = false;

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -311,6 +311,7 @@ public:
     static u16 BGM_INVALID_ID;
     bool isBackgroundMusicPlaying() const { return _CurrentBackgroundMusic != BGM_INVALID_ID; }
     u16 getCurrentBackgroundMusic() const { return _CurrentBackgroundMusic; }
+    const std::string& getCurrentBackgroundMusicFilePath() const { return _CurrentBackgroundMusicFilepath; }
     u16 getBackgroundMusicToStop() const { return _BackgroundMusicToStop; }
     u32 getBackgroundMusicFadeOutToApply() const { return _BgmFadeOutDurationMs; }
     u8 getCurrentBgmMusicVolume() const { return _BackgroundMusicVolume; }
@@ -324,6 +325,8 @@ public:
     virtual u16 getMidiBgmId() { return 0; }
     virtual u16 getMidiBgmToResumeId() { return BGM_INVALID_ID; }
     virtual u32 getMidiSongTableAddress() { return 0; }
+    virtual u32 getStreamTargetAddress() { return 0; }
+    virtual u16 getStreamBgmIdFromAddress(u32 address) { return BGM_INVALID_ID; }
     virtual u8 getMidiBgmState() { return 0; }
     virtual u8 getMidiBgmVolume() { return 0; }
     virtual u32 getBgmFadeOutDuration() { return 0; }
@@ -335,6 +338,8 @@ public:
     std::string getBackgroundMusicName(u16 soundtrackId) const;
     void muteSongSequence(u16 bgmId);
     void stopBackgroundMusic(u16 fadeOutDuration);
+
+    void refreshStreamedMusic();
 
     virtual void refreshMouseStatus() {}
 
@@ -433,6 +438,7 @@ protected:
     bool _ShouldStopReplacementBgmMusic = false;
     bool _ShouldUpdateReplacementBgmMusicVolume = false;
     u16 _CurrentBackgroundMusic = BGM_INVALID_ID;
+    std::string _CurrentBackgroundMusicFilepath;
     u32 _BackgroundMusicDelayAtStart = 0;
     u16 _BackgroundMusicToStop = 0;
     u8 _SoundtrackState = 0;
@@ -441,6 +447,9 @@ protected:
     u8 _BackgroundMusicVolume = 0x7f;
     bool _StoreBackgroundMusicPosition = false;
     bool _ResumeBackgroundMusicPosition = false;
+
+    u32 _CurrentStreamAddress = 0;
+    bool _CurrentBgmIsStream = false;
 
     bool _ShouldGrabMouseCursor = false;
     bool _ShouldReleaseMouseCursor = false;

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -312,7 +312,7 @@ public:
     bool isBackgroundMusicPlaying() const { return _CurrentBackgroundMusic != BGM_INVALID_ID; }
     u16 getCurrentBackgroundMusic() const { return _CurrentBackgroundMusic; }
     u16 getBackgroundMusicToStop() const { return _BackgroundMusicToStop; }
-    bool shouldForceStopMusic() const { return _ForceStopMusic; }
+    u32 getBackgroundMusicFadeOutToApply() const { return _BgmFadeOutDurationMs; }
     u8 getCurrentBgmMusicVolume() const { return _BackgroundMusicVolume; }
     u32 getBgmDelayAtStart() const { return _BackgroundMusicDelayAtStart; }
     bool getStoreBackgroundMusicPosition() const { return _StoreBackgroundMusicPosition; }
@@ -326,6 +326,7 @@ public:
     virtual u32 getMidiSongTableAddress() { return 0; }
     virtual u8 getMidiBgmState() { return 0; }
     virtual u8 getMidiBgmVolume() { return 0; }
+    virtual u32 getBgmFadeOutDuration() { return 0; }
     virtual u16 getSongIdInSongTable(u16 bgmId) { return 0; }
     virtual std::string getBackgroundMusicName(u16 soundtrackId) { return ""; }
     virtual int delayBeforeStartReplacementBackgroundMusic() { return 0; }
@@ -333,7 +334,7 @@ public:
     void refreshBackgroundMusic();
     std::string getBackgroundMusicName(u16 soundtrackId) const;
     void muteSongSequence(u16 bgmId);
-    void stopBackgroundMusic(bool bImmediateStop);
+    void stopBackgroundMusic(u16 fadeOutDuration);
 
     virtual void refreshMouseStatus() {}
 
@@ -435,7 +436,7 @@ protected:
     u32 _BackgroundMusicDelayAtStart = 0;
     u16 _BackgroundMusicToStop = 0;
     u8 _SoundtrackState = 0;
-    bool _ForceStopMusic = false;
+    u32 _BgmFadeOutDurationMs = 0;
     bool _MuteSeqBgm = false;
     u8 _BackgroundMusicVolume = 0x7f;
     bool _StoreBackgroundMusicPosition = false;

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -326,7 +326,7 @@ public:
     virtual u16 getMidiBgmToResumeId() { return BGM_INVALID_ID; }
     virtual u32 getMidiSongTableAddress() { return 0; }
     virtual u32 getStreamTargetAddress() { return 0; }
-    virtual u16 getStreamBgmIdFromAddress(u32 address) { return BGM_INVALID_ID; }
+    virtual u16 getStreamBgmIdFromAddress(u32 address, u32 numSamples) { return BGM_INVALID_ID; }
     virtual u8 getMidiBgmState() { return 0; }
     virtual u8 getMidiBgmVolume() { return 0; }
     virtual u32 getBgmFadeOutDuration() { return 0; }

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -317,7 +317,7 @@ PluginKingdomHeartsDays::PluginKingdomHeartsDays(u32 gameCode)
     }};
 
     StreamedBgmEntries = std::array<StreamedBgmEntry, 1> {{
-        { 0, "Dearly Beloved", 0x0204b6b4,  0x0204b6d4, 0x0204bb14, 0x0204bad4 }
+        { 0, "Dearly Beloved", 2900195, 0x0204b6b4,  0x0204b6d4, 0x0204bb14, 0x0204bad4 }
     }};
 }
 
@@ -2143,10 +2143,10 @@ u32 PluginKingdomHeartsDays::getStreamTargetAddress() {
     return getAnyByCart(STRM_TARGET_ADDRESS_US, STRM_TARGET_ADDRESS_EU, STRM_TARGET_ADDRESS_JP, STRM_TARGET_ADDRESS_JP_REV1);
 }
 
-u16 PluginKingdomHeartsDays::getStreamBgmIdFromAddress(u32 address) {
+u16 PluginKingdomHeartsDays::getStreamBgmIdFromAddress(u32 address, u32 numSamples) {
     auto found = std::find_if(StreamedBgmEntries.begin(), StreamedBgmEntries.end(), [&](const auto& e) {
         u32 cartAddress = getAnyByCart(e.usAddress, e.euAddress, e.jpAddress, e.jprev1Address);
-        return cartAddress == address; });
+        return cartAddress == address && e.numSamples == numSamples; });
     if(found != StreamedBgmEntries.end()) {
         return found->customId;
     }

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -2136,6 +2136,18 @@ u8 PluginKingdomHeartsDays::getMidiBgmVolume() {
     return nds->ARM7Read8(SONG_MASTER_VOLUME_ADDRESS);
 }
 
+u32 PluginKingdomHeartsDays::getBgmFadeOutDuration() {
+    // Caution: this RAM value should be queried on the first frame when the "Stopping" state was set, otherwise fadeout is already in progress!
+    u32 SONG_FADE_OUT_PROGRESS_ADDRESS = getAnyByCart(SONG_ID_ADDRESS_US, SONG_ID_ADDRESS_EU, SONG_ID_ADDRESS_JP, SONG_ID_ADDRESS_JP_REV1) + 0x0A;
+    u8 progress = nds->ARM7Read8(SONG_FADE_OUT_PROGRESS_ADDRESS);
+    // converts value in game frames to milliseconds + some smoothing
+    float valueMs = (progress / 30.0f);
+    if (progress >= 59) { valueMs *= 1.2; }
+    else if (progress >= 29) { valueMs *= 1.5; }
+    else { valueMs *= 2; }
+
+    return std::round(valueMs * 1000);
+}
 
 u16 PluginKingdomHeartsDays::getSongIdInSongTable(u16 bgmId) {
     auto found = std::find_if(BgmEntries.begin(), BgmEntries.end(), [&bgmId](const auto& e) {

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -134,6 +134,11 @@ u32 PluginKingdomHeartsDays::jpGamecode = 1246186329;
 #define SSEQ_TABLE_ADDRESS_JP      0x020E4310
 #define SSEQ_TABLE_ADDRESS_JP_REV1 0x020E4290
 
+#define STRM_TARGET_ADDRESS_US      0x020DD6CC
+#define STRM_TARGET_ADDRESS_EU      0x020DE4AC
+#define STRM_TARGET_ADDRESS_JP      0x020DC82C
+#define STRM_TARGET_ADDRESS_JP_REV1 0x020DC7AC
+
 #define INGAME_MENU_COMMAND_LIST_SETTING_ADDRESS_US      0x02194CC3
 #define INGAME_MENU_COMMAND_LIST_SETTING_ADDRESS_EU      0x02195AA3
 #define INGAME_MENU_COMMAND_LIST_SETTING_ADDRESS_JP      0x02193E23
@@ -309,6 +314,10 @@ PluginKingdomHeartsDays::PluginKingdomHeartsDays(u32 gameCode)
         { 36, 34,   "Boss4",            "Fight and Away" },
         { 37, 35,   "RikuBattle",       "Another Side Battle Version" },
         { 38, 36,   "Xionbattle",       "Vector to the Heavens" }
+    }};
+
+    StreamedBgmEntries = std::array<StreamedBgmEntry, 1> {{
+        { 0, "Dearly Beloved", 0x0204b6b4,  0x0204b6d4, 0x0204bb14, 0x0204bad4 }
     }};
 }
 
@@ -2129,6 +2138,22 @@ u16 PluginKingdomHeartsDays::getMidiBgmToResumeId() {
 u32 PluginKingdomHeartsDays::getMidiSongTableAddress() {
     return getAnyByCart(SSEQ_TABLE_ADDRESS_US, SSEQ_TABLE_ADDRESS_EU, SSEQ_TABLE_ADDRESS_JP, SSEQ_TABLE_ADDRESS_JP_REV1);
 }
+
+u32 PluginKingdomHeartsDays::getStreamTargetAddress() {
+    return getAnyByCart(STRM_TARGET_ADDRESS_US, STRM_TARGET_ADDRESS_EU, STRM_TARGET_ADDRESS_JP, STRM_TARGET_ADDRESS_JP_REV1);
+}
+
+u16 PluginKingdomHeartsDays::getStreamBgmIdFromAddress(u32 address) {
+    auto found = std::find_if(StreamedBgmEntries.begin(), StreamedBgmEntries.end(), [&](const auto& e) {
+        u32 cartAddress = getAnyByCart(e.usAddress, e.euAddress, e.jpAddress, e.jprev1Address);
+        return cartAddress == address; });
+    if(found != StreamedBgmEntries.end()) {
+        return found->customId;
+    }
+
+    return BGM_INVALID_ID;
+}
+
 
 u8 PluginKingdomHeartsDays::getMidiBgmVolume() {
     u32 SONG_MASTER_VOLUME_ADDRESS = getAnyByCart(SONG_ID_ADDRESS_US, SONG_ID_ADDRESS_EU, SONG_ID_ADDRESS_JP, SONG_ID_ADDRESS_JP_REV1) + 0x07;

--- a/src/plugins/PluginKingdomHeartsDays.h
+++ b/src/plugins/PluginKingdomHeartsDays.h
@@ -142,6 +142,7 @@ private:
     u32 getMidiSongTableAddress() override;
     u8 getMidiBgmState() override;
     u8 getMidiBgmVolume() override;
+    u32 getBgmFadeOutDuration() override;
     u16 getSongIdInSongTable(u16 bgmId) override;
     std::string getBackgroundMusicName(u16 bgmId) override;
     int delayBeforeStartReplacementBackgroundMusic() override;

--- a/src/plugins/PluginKingdomHeartsDays.h
+++ b/src/plugins/PluginKingdomHeartsDays.h
@@ -141,7 +141,7 @@ private:
     u16 getMidiBgmToResumeId() override;
     u32 getMidiSongTableAddress() override;
     u32 getStreamTargetAddress() override;
-    u16 getStreamBgmIdFromAddress(u32 address) override;
+    u16 getStreamBgmIdFromAddress(u32 address, u32 numSamples) override;
     u8 getMidiBgmState() override;
     u8 getMidiBgmVolume() override;
     u32 getBgmFadeOutDuration() override;
@@ -153,6 +153,7 @@ private:
     {
         u8 customId = 0;
         char Name[40];
+        u32 numSamples = 0;
         int usAddress;
         int euAddress;
         int jpAddress;

--- a/src/plugins/PluginKingdomHeartsDays.h
+++ b/src/plugins/PluginKingdomHeartsDays.h
@@ -140,12 +140,26 @@ private:
     u16 getMidiBgmId() override;
     u16 getMidiBgmToResumeId() override;
     u32 getMidiSongTableAddress() override;
+    u32 getStreamTargetAddress() override;
+    u16 getStreamBgmIdFromAddress(u32 address) override;
     u8 getMidiBgmState() override;
     u8 getMidiBgmVolume() override;
     u32 getBgmFadeOutDuration() override;
     u16 getSongIdInSongTable(u16 bgmId) override;
     std::string getBackgroundMusicName(u16 bgmId) override;
     int delayBeforeStartReplacementBackgroundMusic() override;
+
+    struct StreamedBgmEntry
+    {
+        u8 customId = 0;
+        char Name[40];
+        int usAddress;
+        int euAddress;
+        int jpAddress;
+        int jprev1Address;
+    };
+
+    std::array<StreamedBgmEntry, 1> StreamedBgmEntries;
 
 
     void refreshMouseStatus();

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -2527,6 +2527,10 @@ u8 PluginKingdomHeartsReCoded::getMidiBgmVolume() {
     return nds->ARM7Read8(SONG_MASTER_VOLUME_ADDRESS);
 }
 
+u32 PluginKingdomHeartsReCoded::getBgmFadeOutDuration() {
+    // TODO find bgm fade counter in RAM
+    return 1000;
+}
 
 u16 PluginKingdomHeartsReCoded::getSongIdInSongTable(u16 bgmId) {
     auto found = std::find_if(BgmEntries.begin(), BgmEntries.end(), [&bgmId](const auto& e) {

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -2528,8 +2528,16 @@ u8 PluginKingdomHeartsReCoded::getMidiBgmVolume() {
 }
 
 u32 PluginKingdomHeartsReCoded::getBgmFadeOutDuration() {
-    // TODO find bgm fade counter in RAM
-    return 1000;
+    // Caution: this RAM value should be queried on the first frame when the "Stopping" state was set, otherwise fadeout is already in progress!
+    u32 SONG_FADE_OUT_PROGRESS_ADDRESS = getU32ByCart(SONG_ID_ADDRESS_US, SONG_ID_ADDRESS_EU, SONG_ID_ADDRESS_JP) + 0x06;
+    u8 progress = nds->ARM7Read8(SONG_FADE_OUT_PROGRESS_ADDRESS);
+    // converts value in game frames to milliseconds + some smoothing
+    float valueMs = (progress / 30.0f);
+    if (progress >= 59) { valueMs *= 1.2; }
+    else if (progress >= 29) { valueMs *= 1.5; }
+    else { valueMs *= 2; }
+
+    return std::round(valueMs * 1000);
 }
 
 u16 PluginKingdomHeartsReCoded::getSongIdInSongTable(u16 bgmId) {

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -2517,6 +2517,13 @@ u8 PluginKingdomHeartsReCoded::getMidiBgmState() {
     return nds->ARM7Read8(SONG_STATE_ADDRESS);
 }
 
+u16 PluginKingdomHeartsReCoded::getMidiBgmToResumeId() {
+    // This byte is set by the audio engine when a "Field" track is getting stopped and we are playing a "Battle" track.
+    // This tells us that the "Field" track will resume playing when the "Battle" track ends.
+    u32 SONG_SECOND_SLOT_ADDRESS = getU32ByCart(SONG_ID_ADDRESS_US, SONG_ID_ADDRESS_EU, SONG_ID_ADDRESS_JP) + 0x0C;
+    return nds->ARM7Read8(SONG_SECOND_SLOT_ADDRESS);
+}
+
 u32 PluginKingdomHeartsReCoded::getMidiSongTableAddress() {
     return getU32ByCart(SSEQ_TABLE_ADDRESS_US, SSEQ_TABLE_ADDRESS_EU, SSEQ_TABLE_ADDRESS_JP);
 }

--- a/src/plugins/PluginKingdomHeartsReCoded.h
+++ b/src/plugins/PluginKingdomHeartsReCoded.h
@@ -132,6 +132,7 @@ private:
 
     bool isBackgroundMusicReplacementImplemented() const override { return true; }
     u16 getMidiBgmId() override;
+    u16 getMidiBgmToResumeId() override;
     u32 getMidiSongTableAddress() override;
     u8 getMidiBgmState() override;
     u8 getMidiBgmVolume() override;

--- a/src/plugins/PluginKingdomHeartsReCoded.h
+++ b/src/plugins/PluginKingdomHeartsReCoded.h
@@ -135,6 +135,7 @@ private:
     u32 getMidiSongTableAddress() override;
     u8 getMidiBgmState() override;
     u8 getMidiBgmVolume() override;
+    u32 getBgmFadeOutDuration() override;
     u16 getSongIdInSongTable(u16 bgmId) override;
     std::string getBackgroundMusicName(u16 bgmId) override;
 


### PR DESCRIPTION
* Improved bgm FadeOuts:
 -- querying the actual duration from RAM, the value is slightly extended to make sure it blends well with FadeIns
 -- replaced logarithmic algo with old linear one
* Proper handling of FadeOut duration and Resume BgmId in Re:Coded
* Handling reuse of wav files by adding an ini file with list of "redirectors"
* Replacement system for streamed bgm:
 -- only "Dearly Beloved" in Days is handled for now
 -- other streams will require more work (proper handling of streaming state, reused ram addresses, timing with HD custcenes...)
* Misc fixes