### PR TITLE
Fixes for stream bgm replacement

### DIFF
--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -977,7 +977,7 @@ void Plugin::refreshBackgroundMusic() {
     if (state != _SoundtrackState) {
         switch(state) {
         case EMidiState::Stopped: {
-            if (_CurrentBackgroundMusic != BGM_INVALID_ID) {
+            if (!_CurrentBgmIsStream && _CurrentBackgroundMusic != BGM_INVALID_ID) {
                 stopBackgroundMusic(0);
             }
             break;

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -325,8 +325,8 @@ public:
     virtual u16 getMidiBgmId() { return 0; }
     virtual u16 getMidiBgmToResumeId() { return BGM_INVALID_ID; }
     virtual u32 getMidiSongTableAddress() { return 0; }
-    virtual u32 getStreamTargetAddress() { return 0; }
-    virtual u16 getStreamBgmIdFromAddress(u32 address, u32 numSamples) { return BGM_INVALID_ID; }
+    virtual u32 getStreamBgmAddress() { return 0; }
+    virtual u16 getStreamBgmCustomIdFromDsId(u8 dsId, u32 numSamples) { return BGM_INVALID_ID; }
     virtual u8 getMidiBgmState() { return 0; }
     virtual u8 getMidiBgmVolume() { return 0; }
     virtual u32 getBgmFadeOutDuration() { return 0; }
@@ -341,6 +341,7 @@ public:
     void stopBackgroundMusic(u16 fadeOutDuration);
 
     void refreshStreamedMusic();
+    void stopBgmStream();
 
     virtual void refreshMouseStatus() {}
 
@@ -450,6 +451,8 @@ protected:
     bool _ResumeBackgroundMusicPosition = false;
     std::map<std::string, std::string> _BgmRedirectors;
 
+    u8 _BgmStreamState = 0;
+    bool _BgmStreamMuted = false;
     u32 _CurrentStreamAddress = 0;
     bool _CurrentBgmIsStream = false;
 

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -341,7 +341,7 @@ public:
     void stopBackgroundMusic(u16 fadeOutDuration);
 
     void refreshStreamedMusic();
-    void stopBgmStream();
+    void stopBgmStream(u32 fadeOutDuration);
 
     virtual void refreshMouseStatus() {}
 

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -341,7 +341,9 @@ public:
     void stopBackgroundMusic(u16 fadeOutDuration);
 
     void refreshStreamedMusic();
-    void stopBgmStream(u32 fadeOutDuration);
+    virtual void onStreamBgmReplacementStarted() {}
+    virtual void muteStreamedMusic();
+    void stopReplacementStreamBgm(u32 fadeOutDuration);
 
     virtual void refreshMouseStatus() {}
 

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -134,10 +134,10 @@ u32 PluginKingdomHeartsDays::jpGamecode = 1246186329;
 #define SSEQ_TABLE_ADDRESS_JP      0x020E4310
 #define SSEQ_TABLE_ADDRESS_JP_REV1 0x020E4290
 
-#define STRM_TARGET_ADDRESS_US      0x020DD6CC
-#define STRM_TARGET_ADDRESS_EU      0x020DE4AC
-#define STRM_TARGET_ADDRESS_JP      0x020DC82C
-#define STRM_TARGET_ADDRESS_JP_REV1 0x020DC7AC
+#define STRM_ADDRESS_US      0x0204B6B4
+#define STRM_ADDRESS_EU      0x0204B6D4
+#define STRM_ADDRESS_JP      0x0204BB14
+#define STRM_ADDRESS_JP_REV1 0x0204BAD4
 
 #define INGAME_MENU_COMMAND_LIST_SETTING_ADDRESS_US      0x02194CC3
 #define INGAME_MENU_COMMAND_LIST_SETTING_ADDRESS_EU      0x02195AA3
@@ -317,7 +317,7 @@ PluginKingdomHeartsDays::PluginKingdomHeartsDays(u32 gameCode)
     }};
 
     StreamedBgmEntries = std::array<StreamedBgmEntry, 1> {{
-        { 0, "Dearly Beloved", 2900195, 0x0204b6b4,  0x0204b6d4, 0x0204bb14, 0x0204bad4 }
+        { 0x5a, 0, "Dearly Beloved", 2900195 }
     }};
 }
 
@@ -2139,14 +2139,13 @@ u32 PluginKingdomHeartsDays::getMidiSongTableAddress() {
     return getAnyByCart(SSEQ_TABLE_ADDRESS_US, SSEQ_TABLE_ADDRESS_EU, SSEQ_TABLE_ADDRESS_JP, SSEQ_TABLE_ADDRESS_JP_REV1);
 }
 
-u32 PluginKingdomHeartsDays::getStreamTargetAddress() {
-    return getAnyByCart(STRM_TARGET_ADDRESS_US, STRM_TARGET_ADDRESS_EU, STRM_TARGET_ADDRESS_JP, STRM_TARGET_ADDRESS_JP_REV1);
+u32 PluginKingdomHeartsDays::getStreamBgmAddress() {
+    return getAnyByCart(STRM_ADDRESS_US, STRM_ADDRESS_EU, STRM_ADDRESS_JP, STRM_ADDRESS_JP_REV1);
 }
 
-u16 PluginKingdomHeartsDays::getStreamBgmIdFromAddress(u32 address, u32 numSamples) {
-    auto found = std::find_if(StreamedBgmEntries.begin(), StreamedBgmEntries.end(), [&](const auto& e) {
-        u32 cartAddress = getAnyByCart(e.usAddress, e.euAddress, e.jpAddress, e.jprev1Address);
-        return cartAddress == address && e.numSamples == numSamples; });
+u16 PluginKingdomHeartsDays::getStreamBgmCustomIdFromDsId(u8 dsId, u32 numSamples) {
+    auto found = std::find_if(StreamedBgmEntries.begin(), StreamedBgmEntries.end(), [&dsId, &numSamples](const auto& e) {
+        return e.dsId == dsId && e.numSamples == numSamples; });
     if(found != StreamedBgmEntries.end()) {
         return found->customId;
     }

--- a/src/plugins/PluginKingdomHeartsDays.h
+++ b/src/plugins/PluginKingdomHeartsDays.h
@@ -140,8 +140,8 @@ private:
     u16 getMidiBgmId() override;
     u16 getMidiBgmToResumeId() override;
     u32 getMidiSongTableAddress() override;
-    u32 getStreamTargetAddress() override;
-    u16 getStreamBgmIdFromAddress(u32 address, u32 numSamples) override;
+    u32 getStreamBgmAddress() override;
+    u16 getStreamBgmCustomIdFromDsId(u8 dsId, u32 numSamples) override;
     u8 getMidiBgmState() override;
     u8 getMidiBgmVolume() override;
     u32 getBgmFadeOutDuration() override;
@@ -151,17 +151,13 @@ private:
 
     struct StreamedBgmEntry
     {
+        u8 dsId = 0;
         u8 customId = 0;
         char Name[40];
         u32 numSamples = 0;
-        int usAddress;
-        int euAddress;
-        int jpAddress;
-        int jprev1Address;
     };
 
     std::array<StreamedBgmEntry, 1> StreamedBgmEntries;
-
 
     void refreshMouseStatus();
 

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -133,6 +133,9 @@ u32 PluginKingdomHeartsReCoded::jpGamecode = 1245268802;
 #define SSEQ_TABLE_ADDRESS_EU      0x020E2D10
 #define SSEQ_TABLE_ADDRESS_JP      0x020E0B10
 
+#define STRM_ADDRESS_US      0x0205E790
+#define STRM_ADDRESS_EU      0x0205E790
+#define STRM_ADDRESS_JP      0x0205E5B0
 
 #define SWITCH_TARGET_PRESS_FRAME_LIMIT   100
 #define SWITCH_TARGET_TIME_BETWEEN_SWITCH 20
@@ -308,6 +311,10 @@ PluginKingdomHeartsReCoded::PluginKingdomHeartsReCoded(u32 gameCode)
         { 38, 38,   "LastBoss", "" },
         { 39, 39,   "Debug", "" },
         { 40, 40,   "Rik_BG", "" }
+    }};
+
+    StreamedBgmEntries = std::array<StreamedBgmEntry, 1> {{
+        { 0X64, 41, "Dearly Beloved", 3212253 }
     }};
 }
 
@@ -2526,6 +2533,20 @@ u16 PluginKingdomHeartsReCoded::getMidiBgmToResumeId() {
 
 u32 PluginKingdomHeartsReCoded::getMidiSongTableAddress() {
     return getU32ByCart(SSEQ_TABLE_ADDRESS_US, SSEQ_TABLE_ADDRESS_EU, SSEQ_TABLE_ADDRESS_JP);
+}
+
+u32 PluginKingdomHeartsReCoded::getStreamBgmAddress() {
+    return getU32ByCart(STRM_ADDRESS_US, STRM_ADDRESS_EU, STRM_ADDRESS_JP);
+}
+
+u16 PluginKingdomHeartsReCoded::getStreamBgmCustomIdFromDsId(u8 dsId, u32 numSamples) {
+    auto found = std::find_if(StreamedBgmEntries.begin(), StreamedBgmEntries.end(), [&](const auto& e) {
+        return e.dsId == dsId && e.numSamples == numSamples; });
+    if(found != StreamedBgmEntries.end()) {
+        return found->customId;
+    }
+
+    return BGM_INVALID_ID;
 }
 
 u8 PluginKingdomHeartsReCoded::getMidiBgmVolume() {

--- a/src/plugins/PluginKingdomHeartsReCoded.h
+++ b/src/plugins/PluginKingdomHeartsReCoded.h
@@ -134,11 +134,24 @@ private:
     u16 getMidiBgmId() override;
     u16 getMidiBgmToResumeId() override;
     u32 getMidiSongTableAddress() override;
+    u32 getStreamBgmAddress() override;
+    u16 getStreamBgmCustomIdFromDsId(u8 dsId, u32 numSamples) override;
     u8 getMidiBgmState() override;
     u8 getMidiBgmVolume() override;
     u32 getBgmFadeOutDuration() override;
     u16 getSongIdInSongTable(u16 bgmId) override;
     std::string getBackgroundMusicName(u16 bgmId) override;
+
+    struct StreamedBgmEntry
+    {
+        u8 dsId = 0;
+        u8 customId = 0;
+        char Name[40];
+        u32 numSamples = 0;
+    };
+
+    std::array<StreamedBgmEntry, 1> StreamedBgmEntries;
+
 
     bool isBufferBlack(unsigned int* buffer);
     u32* topScreen2DTexture();

--- a/src/plugins/PluginKingdomHeartsReCoded.h
+++ b/src/plugins/PluginKingdomHeartsReCoded.h
@@ -151,7 +151,9 @@ private:
     };
 
     std::array<StreamedBgmEntry, 1> StreamedBgmEntries;
-
+    u8 _MutedStreamBlocksCount = 0;
+    void onStreamBgmReplacementStarted() override;
+    void muteStreamedMusic() override;
 
     bool isBufferBlack(unsigned int* buffer);
     u32* topScreen2DTexture();


### PR DESCRIPTION
- better method to mute the original stream sound, by simply setting stream volume to 0. The game doesn't complain as much as when STRM header was altered.
- better handling of changes by monitoring the stream state (similar to the midi bgm state)
- also found something that looks like a unique ID in the STRM data in RAM. Better to identify streams.
- added a few calls to stopBgmStream() in a few places to make sure replacement stream is always stopped if a state is not handled
- replacement streams also work in Re:Coded now! It required an additional change to erase the first audio block that doesn't get its volume immediately set to 0.