### PR TITLE
Fix horrible bugs with SFX sounds delayed or stuck

### DIFF
--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -988,27 +988,31 @@ void Plugin::refreshBackgroundMusic() {
         }
         case EMidiState::PrePlay: {
             // Loaded has finished but bgm is not marked as "Playing" yet
-            break;
-        }
-        case EMidiState::Playing: {
-            // SSEQ is loaded and ready to play
             if (bgmId != _CurrentBackgroundMusic) {
                 // Previous bgm should have already been stopped, but just in case:
                 stopBackgroundMusic(1000);
 
                 std::string replacementBgmPath = getReplacementBackgroundMusicFilePath(bgmId);
                 if (replacementBgmPath != "") {
-                    _ShouldStartReplacementBgmMusic = true;
+                    _PendingReplacmentBgmMusicStart = true;
                     _CurrentBackgroundMusicFilepath = replacementBgmPath;
                     _CurrentBackgroundMusic = bgmId;
                     u16 bgmResumeId = getMidiBgmToResumeId();
                     _ResumeBackgroundMusicPosition = (bgmResumeId == _CurrentBackgroundMusic && bgmResumeId != BGM_INVALID_ID);
-                    _BackgroundMusicDelayAtStart = delayBeforeStartReplacementBackgroundMusic(bgmId);
                     _CurrentBgmIsStream = false;
                     _MuteSeqBgm = true;
                 } else {
                     _CurrentBackgroundMusic = BGM_INVALID_ID;
                 }
+            }
+            break;
+        }
+        case EMidiState::Playing: {
+            // SSEQ is loaded and ready to play
+            if (_PendingReplacmentBgmMusicStart) {
+                _ShouldStartReplacementBgmMusic = true;
+                _BackgroundMusicDelayAtStart = delayBeforeStartReplacementBackgroundMusic(bgmId);
+                _PendingReplacmentBgmMusicStart = false;
             }
             break;
         }

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -438,6 +438,7 @@ protected:
     bool _PausedReplacementBgmMusic = false;
     bool _ShouldPauseReplacementBgmMusic = false;
     bool _ShouldUnpauseReplacementBgmMusic = false;
+    bool _PendingReplacmentBgmMusicStart = false;
     bool _ShouldStartReplacementBgmMusic = false;
     bool _ShouldStopReplacementBgmMusic = false;
     bool _ShouldUpdateReplacementBgmMusicVolume = false;


### PR DESCRIPTION
Something goes horribly wrong when calling the SSEQ muting process when the status is set to "Playing", it's probably too late in the workflow and it might touch RAM data it's not supposed to, somehow. The muting should be done as soon as the loading has finished, like before, when status "PrePlay" is set. But we still only play the replacement song when the status is "Playing".