### PR TITLE
Lua scripting support for MelonMix plugins

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -7,7 +7,7 @@
 ## Linux
 1. Install dependencies:
    * Ubuntu:
-     * All versions: `sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev libarchive-dev libenet-dev libzstd-dev libflac-dev`
+     * All versions: `sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev libarchive-dev libenet-dev libzstd-dev libflac-dev liblua5.4-dev`
      * 24.04: `sudo apt install qt6-{base,base-private,multimedia,svg}-dev`
      * 22.04: `sudo apt install qtbase6-dev qtbase6-private-dev qtmultimedia6-dev libqt6svg6-dev`
      * Older versions: `sudo apt install qtbase5-dev qtbase5-private-dev qtmultimedia5-dev libqt5svg5-dev`  

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
           qt6.qtbase
           qt6.qtmultimedia
           SDL2
+          lua
           zstd
           libarchive
           flac

--- a/luaScripts/MelonMixShapes.lua
+++ b/luaScripts/MelonMixShapes.lua
@@ -1,0 +1,317 @@
+
+local SCREEN_SCALE = 6.0
+
+--utility function to implement enumeration
+local enum = function(keys)
+    local Enum = {}
+    for index, value in ipairs(keys) do
+        Enum[value] = index-1
+    end
+    return Enum
+end
+
+_shape = enum{
+    "Square"
+}
+
+_corner = enum{
+    "PreservePosition",
+    "Center",
+    "TopLeft",
+    "Top",
+    "TopRight",
+    "Right",
+    "BottomRight",
+    "Bottom",
+    "BottomLeft",
+    "Left"
+}
+
+_mirror = {
+    None = 0x00,
+    X = 0x80,
+    Y = 0x10,
+    XY = 0x18
+}
+
+--utility function to help implement c-like structs / classes
+local function newStruct(self,init)
+    local newStruct = init or {}
+    setmetatable(newStruct,self)
+    self.__index = self
+    return newStruct
+end
+
+--generic vector object, with "bytes" method to convert to packed data string 
+local vector = {}
+function vector:new(init)
+    return newStruct(self,init)
+end
+function vector:bytes()
+    error("Bytes function not found for this vector...")
+end
+
+local vec2 = vector:new({x=0.0,y=0.0})
+function vec2:bytes()
+    return string.pack("ff",self.x,self.y)
+end
+local ivec4 = vector:new({x=0,y=0,z=0,w=0})
+function ivec4:bytes()
+    return string.pack("iiii",self.x,self.y,self.z,self.w)
+end
+local vec4 = vector:new({x=0.0,y=0.0,z=0.0,w=0.0})
+function vec4:bytes()
+    return string.pack("ffff",self.x,self.y,self.z,self.w)
+end
+
+local ShapeData2D = {}
+function ShapeData2D:new()
+    local init = {
+        sourceScale = vec2:new({x=1.0,y=1.0}),
+        
+        effects = 0,
+        -- 0x01 => invertGrayScaleColors
+        -- 0x02 => crop corner as triangle
+        -- 0x04 => rounded corners
+        -- 0x08 => mirror X
+        -- 0x10 => mirror Y
+        -- 0x20 => manipulate transparency
+        
+        opacity = 1.0,
+        
+        squareInitialCoords = ivec4:new({x=0,y=0,z=256,w=192}),
+        squareFinalCoords = vec4:new(),
+        
+        fadeBorderSize = vec4:new(),
+        
+        squareCornersModifier = vec4:new(),
+        
+        colorToAlpha = ivec4:new(),
+        singleColorToAlpha = ivec4:new()
+    }
+    return newStruct(self,init)
+end
+
+--UBO-compatible format
+function ShapeData2D:bytes() 
+    return table.concat({
+        self.sourceScale:bytes(),-- 8 bytes (X factor, Y factor)
+        string.pack("i",self.effects),
+        string.pack("f",self.opacity),
+        self.squareInitialCoords:bytes(),-- 16 bytes (X, Y, Width, Height)
+        self.squareFinalCoords:bytes(),-- 16 bytes (X, Y, Width, Height)
+        self.fadeBorderSize:bytes(),-- 16 bytes (left fade, top fade, right fade, down fade)
+        self.squareCornersModifier:bytes(),-- 16 bytes (top left, top right, bottom left, bottom right)
+        self.colorToAlpha:bytes(),-- 16 bytes (RGBA, and the A acts as an enabled/disabled toggle)
+        self.singleColorToAlpha:bytes() -- 16 bytes (RGBA, and the A acts as an enabled/disabled toggle)
+    })
+end
+
+ShapeBuilder2D ={}
+function ShapeBuilder2D:square()
+    return newStruct(self,{
+        shapeData           = ShapeData2D:new(),
+        _shape              = _shape.Square,
+        _fromBottomScreen   = false,
+        _corner             = _corner.PreservePosition,
+        _hudScale           = 1.0,
+        _margin             = vec4:new()
+    })
+end
+
+function ShapeBuilder2D:fromBottomScreen()
+    self._fromBottomScreen = true;
+    return self
+end
+
+function ShapeBuilder2D:placeAtCorner(corner)
+    self._corner = corner;
+    return self
+end
+
+function ShapeBuilder2D:sourceScale(scale)
+    self.shapeData.sourceScale.x = scale
+    self.shapeData.sourceScale.y = scale
+    return self
+end
+
+function ShapeBuilder2D:hudScale(hudScale)
+    self._hudScale = hudScale;
+    return self
+end
+
+function ShapeBuilder2D:preserveDsScale()
+    local mulScale = SCREEN_SCALE/self._hudScale
+    self.shapeData.sourceScale.x = self.shapeData.sourceScale.x * mulScale
+    self.shapeData.sourceScale.y = self.shapeData.sourceScale.y * mulScale
+    return self
+end 
+
+function ShapeBuilder2D:fromPosition(x,y)
+    if self._shape == _shape.Square then 
+        self.shapeData.squareInitialCoords.x = x
+        self.shapeData.squareInitialCoords.y = y
+    end
+    return self
+end
+
+function ShapeBuilder2D:withSize(width,height)
+    if self._shape == _shape.Square then 
+        self.shapeData.squareInitialCoords.z = width
+        self.shapeData.squareInitialCoords.w = height
+    end
+    return self
+end
+
+function ShapeBuilder2D:withMargin(left,top,right,bottom)
+    self._margin.x = left
+    self._margin.y = top
+    self._margin.z = right
+    self._margin.w = bottom
+    return self
+end
+
+function ShapeBuilder2D:fadeBorderSize(left,top,right,bottom)
+    self.shapeData.effects = self.shapeData.effects | 0x20
+    self.shapeData.fadeBorderSize.x = left
+    self.shapeData.fadeBorderSize.y = top
+    self.shapeData.fadeBorderSize.z = right
+    self.shapeData.fadeBorderSize.w = bottom
+    return self
+end
+
+function ShapeBuilder2D:invertGrayScaleColors()
+    self.shapeData.effects = self.shapeData.effects | 0x1
+    return self
+end
+
+function ShapeBuilder2D:mirror(mirror)
+    self.shapeData.effects = self.shapeData.effects | mirror
+    return self
+end
+
+function ShapeBuilder2D:cropSquareCorners(topLeft,topRight,bottomLeft,bottomRight)
+    self.shapeData.effects = self.shapeData.effects | 0x2
+    self.shapeData.squareCornersModifier.x = topLeft
+    self.shapeData.squareCornersModifier.y = topRight
+    self.shapeData.squareCornersModifier.z = bottomLeft
+    self.shapeData.squareCornersModifier.w = bottomRight
+    return self
+end
+
+function ShapeBuilder2D:squareBorderRadius(topLeft,topRight,bottomLeft,bottomRight)
+    self.shapeData.effects = self.shapeData.effects | 0x4
+    self.shapeData.squareCornersModifier.x = topLeft
+    self.shapeData.squareCornersModifier.y = topRight
+    self.shapeData.squareCornersModifier.z = bottomLeft
+    self.shapeData.squareCornersModifier.w = bottomRight
+    return self
+end
+
+function ShapeBuilder2D:squareBorderRadius(radius)
+    return self:squareBorderRadius(radius, radius, radius, radius)
+end
+
+function ShapeBuilder2D:opacity(opacity)
+    self.shapeData.effects = self.shapeData.effects | 0x20
+    self.shapeData.opacity = opacity
+    return self
+end
+
+function ShapeBuilder2D:colorToAlpha(red,green,blue)
+    self.shapeData.effects = self.shapeData.effects | 0x20
+    self.shapeData.colorToAlpha.x = red >> 2
+    self.shapeData.colorToAlpha.y = green >> 2
+    self.shapeData.colorToAlpha.z = blue >> 2
+    self.shapeData.colorToAlpha.w = 1
+    return self
+end
+
+function ShapeBuilder2D:singleColorToAlpha(red,green,blue)
+    self.shapeData.effects = self.shapeData.effects | 0x20
+    self.shapeData.singleColorToAlpha.x = red >> 2
+    self.shapeData.singleColorToAlpha.y = green >> 2
+    self.shapeData.singleColorToAlpha.z = blue >> 2
+    self.shapeData.singleColorToAlpha.w = 1
+    return self
+end
+
+function ShapeBuilder2D:precompute3DCoordinatesOf2DSquareShape(aspectRatio)
+    local iuTexScale = SCREEN_SCALE/self._hudScale
+
+    local ScreenWidth = 256.0*iuTexScale
+    local ScreenHeight = 192.0*iuTexScale
+
+    local scaleX = self.shapeData.sourceScale.x
+    local scaleY = self.shapeData.sourceScale.y
+
+    local heightScale = 1.0/aspectRatio
+
+    local squareFinalWidth = self.shapeData.squareInitialCoords.z*scaleX*heightScale
+    local squareFinalHeight = self.shapeData.squareInitialCoords.w*scaleY
+
+    local squareFinalX1 = 0.0
+    local squareFinalY1 = 0.0
+
+    local function switch(condition,cases) return cases[condition]() end
+
+    switch(self._corner,
+    {
+        [_corner.PreservePosition] = function()
+            squareFinalX1 = (self.shapeData.squareInitialCoords.x + self.shapeData.squareInitialCoords.z/2)*scaleX - squareFinalWidth/2
+            squareFinalY1 = (self.shapeData.squareInitialCoords.y + self.shapeData.squareInitialCoords.w/2)*scaleY - squareFinalHeight/2
+        end,
+        [_corner.Center] = function()
+            squareFinalX1 = (ScreenWidth - squareFinalWidth)/2
+            squareFinalY1 = (ScreenHeight - squareFinalHeight)/2
+        end,
+        [_corner.TopLeft] = function()
+        end,
+        [_corner.Top] = function()
+            squareFinalX1 = (ScreenWidth - squareFinalWidth)/2
+        end,
+        [_corner.TopRight] = function()
+            squareFinalX1 = ScreenWidth - squareFinalWidth
+        end,
+        [_corner.Right] = function()
+            squareFinalX1 = ScreenWidth - squareFinalWidth
+            squareFinalY1 = (ScreenHeight - squareFinalHeight)/2
+        end,
+        [_corner.BottomRight] = function()
+            squareFinalX1 = ScreenWidth - squareFinalWidth
+            squareFinalY1 = ScreenHeight - squareFinalHeight
+        end,
+        [_corner.Bottom] = function()
+            squareFinalX1 = (ScreenWidth - squareFinalWidth)/2
+            squareFinalY1 = ScreenHeight - squareFinalHeight
+        end,
+        [_corner.BottomLeft] = function()
+            squareFinalY1 = ScreenHeight - squareFinalHeight
+        end,
+        [_corner.Left] = function()
+            squareFinalY1 = (ScreenHeight - squareFinalHeight)/2
+        end,
+    })
+
+    squareFinalX1 = squareFinalX1 + (self._margin.x - self._margin.z)*heightScale
+    squareFinalY1 = squareFinalY1 + (self._margin.y - self._margin.w)
+
+    local squareFinalX2 = squareFinalX1 + squareFinalWidth
+    local squareFinalY2 = squareFinalY1 + squareFinalHeight
+
+    self.shapeData.squareFinalCoords.x = squareFinalX1
+    self.shapeData.squareFinalCoords.y = squareFinalY1
+    self.shapeData.squareFinalCoords.z = squareFinalX2
+    self.shapeData.squareFinalCoords.w = squareFinalY2
+end
+
+function ShapeBuilder2D:build(aspectRatio)
+    if self._fromBottomScreen then 
+        self.shapeData.squareInitialCoords.y = self.shapeData.squareInitialCoords.y + 192
+    end
+    if self._shape == _shape.Square then 
+        self:precompute3DCoordinatesOf2DSquareShape(aspectRatio)
+    end
+    return self.shapeData
+end
+

--- a/luaScripts/testPlugin.lua
+++ b/luaScripts/testPlugin.lua
@@ -1,0 +1,88 @@
+
+dofile "MelonMixShapes.lua"
+
+local hudScale = 5
+local aspectRatio = GetCurrentAspectRatio()
+
+local shapeData_A = ShapeBuilder2D:square()
+    :fromBottomScreen()
+    :fromPosition(0,0)
+    :withSize(256,192)
+    :placeAtCorner(_corner.TopLeft)
+    :sourceScale(1.5)
+    :hudScale(hudScale)
+    :build(1)
+
+local shapeData_B = ShapeBuilder2D:square()
+    :fromPosition(0,0)
+    :withSize(256,192)
+    :placeAtCorner(_corner.TopLeft)
+    :sourceScale(0.5)
+    :fadeBorderSize(0,0,2.5,2.5)
+    :opacity(0.66)
+    :hudScale(hudScale)
+    :build(1)
+
+local ScreenShape = PushShapeData(shapeData_A:bytes())
+local MiniMapShape = PushShapeData(shapeData_B:bytes())
+
+-- Set current shapes that should be loaded
+SetShapes{MiniMapShape,ScreenShape}
+
+--Update Game scene to signal the shader to update
+SetGameScene(3)
+local miniMapIsup = true
+
+
+function toggleMiniMap() --Function to toggle showing the bottom Screen as a miniMap
+    miniMapIsup = not miniMapIsup 
+    if miniMapIsup then
+        SetShapes{MiniMapShape,ScreenShape}
+        SetGameScene(3)
+    else
+        SetShapes{ScreenShape}
+        SetGameScene(2)
+    end
+end
+
+local updateFlags = {}
+--_Update is called once every frame by MelonDS    
+function _Update() 
+    updateFlags = {}
+    if KeyPress("K") then 
+        toggleMiniMap() 
+    end
+end
+
+
+--TODO: write this logic directly into the backend so it dosen't need to be added in lua...
+
+--true if key is currently held down
+function KeyHeld(keyStr)
+    if not updateFlags.HeldMask then updateFlags.HeldMask = HeldKeys() end
+    return updateFlags.HeldMask[string.byte(keyStr:sub(1,1))]
+end
+
+local PressedKeys = {}
+--check if key is held on this frame but was not last frame
+function KeyPress(keyStr)
+    if not updateFlags.PressedMask then updateFlags.PressedMask = {} end
+
+    if updateFlags.PressedMask[keyStr] == nil then 
+        if KeyHeld(keyStr) then 
+            local allreadyPressed = PressedKeys[keyStr]
+            PressedKeys[keyStr] = true
+            updateFlags.PressedMask[keyStr] = not allreadyPressed
+        else
+            PressedKeys[keyStr] = false
+            updateFlags.PressedMask[keyStr] = false
+        end
+    end
+
+    return updateFlags.PressedMask[keyStr]
+end
+
+local PressedKeys = {}
+
+
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(core STATIC
     plugins/PluginKingdomHeartsReCoded.cpp
     plugins/PluginHarvestMoonDsCute.cpp
     plugins/PluginMetroidPrimeHunters.cpp
+    plugins/PluginTemplate.cpp
 
     sha1/sha1.c
     tiny-AES-c/aes.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(core STATIC
     plugins/PluginKingdomHeartsReCoded.cpp
     plugins/PluginHarvestMoonDsCute.cpp
     plugins/PluginMetroidPrimeHunters.cpp
+    plugins/PluginTemplateLua.cpp
     #plugins/PluginTemplate.cpp
 
     sha1/sha1.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,7 +72,7 @@ add_library(core STATIC
     plugins/PluginKingdomHeartsReCoded.cpp
     plugins/PluginHarvestMoonDsCute.cpp
     plugins/PluginMetroidPrimeHunters.cpp
-    plugins/PluginTemplate.cpp
+    #plugins/PluginTemplate.cpp
 
     sha1/sha1.c
     tiny-AES-c/aes.c

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -66,6 +66,8 @@ set(SOURCES_QT_SDL
 
     LANDialog.cpp
     NetplayDialog.cpp
+
+    LuaMain.cpp
 )
 
 option(USE_QT6 "Use Qt 6 instead of Qt 5" ON)
@@ -84,6 +86,7 @@ set(CMAKE_AUTORCC ON)
 
 find_package(Threads REQUIRED)
 find_package(PkgConfig REQUIRED)
+find_package(Lua REQUIRED)
 
 if (BUILD_STATIC)
     list(APPEND PKG_CONFIG_EXECUTABLE "--static")
@@ -182,6 +185,7 @@ endif()
 target_include_directories(melonDS PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/..")
+target_include_directories(melonDS PRIVATE ${LUA_INCLUDE_DIR})
 
 if (USE_QT6)
     target_include_directories(melonDS PUBLIC ${Qt6Gui_PRIVATE_INCLUDE_DIRS})
@@ -190,7 +194,7 @@ else()
 endif()
 target_link_libraries(melonDS PRIVATE core)
 target_link_libraries(melonDS PRIVATE PkgConfig::SDL2 PkgConfig::LibArchive PkgConfig::Zstd)
-target_link_libraries(melonDS PRIVATE ${QT_LINK_LIBS} ${CMAKE_DL_LIBS})
+target_link_libraries(melonDS PRIVATE ${QT_LINK_LIBS} ${CMAKE_DL_LIBS} ${LUA_LIBRARIES})
 
 if (WIN32)
     option(QT_DEPLOY_FFMPEG "Bundle ffmpeg with the app on Windows" ON)

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -160,6 +160,9 @@ public:
     SDL_Joystick* getJoystick() { return joystick; }
     void autoMapJoystick();
 
+    std::vector<int> heldKeys;
+    std::vector<int> keyStrokes;
+
     Plugins::Plugin* plugin = nullptr;
 
     void touchScreen(int x, int y);
@@ -305,6 +308,9 @@ public:
     bool fastForwardToggled;
     bool slowmoToggled;
     bool doAudioSync;
+
+    melonDS::u32 getInputMask(){return inputMask;}
+    Sint16 getJoyStickAxis(int axisNum);
 private:
 
     std::unique_ptr<melonDS::Savestate> backupState;

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -415,8 +415,10 @@ int getEventKeyVal(QKeyEvent* event)
 
 void EmuInstance::onKeyPress(QKeyEvent* event)
 {
+    heldKeys.push_back(event->key());
     int keyHK = getEventKeyVal(event);
     int keyKP = keyHK;
+    keyStrokes.push_back(keyHK);
     if (event->modifiers() != Qt::KeypadModifier)
         keyKP &= ~event->modifiers();
 
@@ -442,6 +444,7 @@ void EmuInstance::onKeyPress(QKeyEvent* event)
 
 void EmuInstance::onKeyRelease(QKeyEvent* event)
 {
+    heldKeys.erase(std::find(heldKeys.begin(),heldKeys.end(),event->key()));
     int keyHK = getEventKeyVal(event);
     int keyKP = keyHK;
     if (event->modifiers() != Qt::KeypadModifier)
@@ -592,6 +595,16 @@ void EmuInstance::inputProcess()
     hotkeyPress = hotkeyMask & ~lastHotkeyMask;
     hotkeyRelease = lastHotkeyMask & ~hotkeyMask;
     lastHotkeyMask = hotkeyMask;
+}
+
+//Used By Lua Scripts
+Sint16 EmuInstance::getJoyStickAxis(int axisNum){
+    if (joystick)
+    {
+        axisNum = axisNum & 0xF;
+        return SDL_JoystickGetAxis(joystick, axisNum);
+    }
+    return 0;
 }
 
 void EmuInstance::touchScreen(int x, int y)

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -549,6 +549,9 @@ void EmuThread::run()
         }
 
         handleMessages();
+
+        //Lua Script Stuff (-for now happens at the end of each frame regardless of emuStatus)
+        emit signalLuaUpdate();
     }
 }
 

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -164,6 +164,8 @@ signals:
 
     void syncVolumeLevel();
 
+    void signalLuaUpdate();
+
     void windowStartBgmMusic(quint16 bgmId, quint8 volume, bool bStoreResumePos, quint32 delayAtStart, QString filePath);
     void windowStopBgmMusic(quint16 bgmId, bool bStoreResumePos, quint32 fadeOutDuration);
     void windowPauseBgmMusic();

--- a/src/frontend/qt_sdl/LuaMain.cpp
+++ b/src/frontend/qt_sdl/LuaMain.cpp
@@ -1,0 +1,712 @@
+#include "LuaMain.h"
+#include <filesystem>
+#include <QDir>
+#include <QFileDialog>
+#include <QPushButton>
+#include <QGuiApplication>
+#include <QScrollBar>
+#include <QPainter>
+#include "types.h"
+#include "NDS.h"
+#include <SDL_joystick.h>
+#include <NDS_Header.h>
+#include "main.h"
+#include "../plugins/PluginTemplateLua.h"
+
+LuaBundle::LuaBundle(LuaConsoleDialog* dialog, EmuInstance* inst)
+{
+    emuInstance = inst;
+    emuThread = emuInstance->getEmuThread();
+    luaDialog = dialog;
+    overlays = new std::vector<OverlayCanvas>;
+    imageHash = new QHash<QString, QImage>;
+}
+
+LuaConsoleDialog::LuaConsoleDialog(QWidget* parent) : QDialog(parent)
+{
+    QWidget* w = parent;
+    MainWindow* mainWindow;
+    for (;;) //copied from ScreenPanel in Screen.cpp
+    {
+        mainWindow = qobject_cast<MainWindow*>(w);
+        if (mainWindow) break;
+        w = w->parentWidget();
+        if (!w) break;
+    }
+    bundle = new LuaBundle(this,mainWindow->getEmuInstance());
+    console = new LuaConsole(this);
+    console->setGeometry(0,20,302,80);
+    bar = console->verticalScrollBar();
+    buttonPausePlay = new QPushButton("Pause/UnPause",this);
+    buttonPausePlay->setGeometry(0,0,100,20);
+    buttonStartStop = new QPushButton("Stop",this);
+    buttonStartStop->setGeometry(101,0,100,20);
+    buttonOpenScript = new QPushButton("OpenLuaFile",this);
+    buttonOpenScript->setGeometry(202,0,100,20);
+    connect(buttonOpenScript,&QPushButton::clicked,this,&LuaConsoleDialog::onOpenScript);
+    connect(buttonStartStop,&QPushButton::clicked,this,&LuaConsoleDialog::onStop);
+    connect(buttonPausePlay,&QPushButton::clicked,this,&LuaConsoleDialog::onPausePlay);
+    this->setWindowTitle("Lua Script");
+}
+
+void LuaConsoleDialog::closeEvent(QCloseEvent *event)
+{
+    onStop();
+    bundle->overlays->clear();
+    flagClosed = true;
+    event->accept();
+}
+
+void LuaConsoleDialog::onOpenScript()
+{
+    QFileInfo file = QFileInfo(QFileDialog::getOpenFileName(this, "Load Lua Script",QDir::currentPath()));
+    if (!file.exists()) return;
+    currentScript = file;
+    bundle->flagNewLua = true;
+}
+
+LuaConsole::LuaConsole(QWidget* parent)
+{
+    this->setParent(parent);
+}
+
+void LuaConsole::onGetText(const QString& string)
+{
+    this->appendPlainText(string);
+    QScrollBar* bar = verticalScrollBar();
+    bar->setValue(bar->maximum());
+}
+
+void LuaBundle::printText(QString string)
+{
+    this->luaDialog->console->onGetText(string);
+}
+
+void LuaConsoleDialog::onLuaSaveState(QString string)
+{
+    emit signalLuaSaveState(string);
+}
+
+void LuaConsoleDialog::onLuaLoadState(QString string)
+{
+    emit signalLuaLoadState(string);
+}
+
+void LuaConsole::onClear()
+{
+    this->clear();
+}
+
+LuaFunction::LuaFunction(luaFunctionPointer cf,const char* n,std::vector<LuaFunction*>* container)
+{
+    this->cfunction = cf;
+    this->name = n;
+    container->push_back(this);
+}
+
+static_assert(sizeof(LuaBundle*) <= LUA_EXTRASPACE,"LUA_EXTRASPACE too small");
+
+LuaBundle* get_bundle(lua_State * L)
+{
+	LuaBundle* pBundle;
+	std::memcpy(&pBundle, lua_getextraspace(L), sizeof(LuaBundle*));
+	return pBundle;
+}
+
+#define MELON_LUA_HOOK_INSTRUCTION_COUNT 50 //number of vm instructions between hook calls
+void luaHookFunction(lua_State* L, lua_Debug *arg)
+{
+    LuaBundle* bundle = get_bundle(L);
+    if (bundle->flagStop and (arg->event == LUA_HOOKCOUNT)) 
+        luaL_error(L, "Force Stopped");
+}
+
+std::vector<LuaFunction*> definedLuaFunctions;//List of all defined lua functions
+
+void LuaBundle::createLuaState()
+{
+    if (!flagNewLua) return;
+    overlays->clear();
+    flagNewLua = false;
+    luaState = nullptr;
+    QByteArray fileName = luaDialog->currentScript.fileName().toLocal8Bit();
+    QString filedir = luaDialog->currentScript.dir().path();
+    lua_State* L = luaL_newstate();
+    LuaBundle* pBundle = this;
+    std::memcpy(lua_getextraspace(L), &pBundle, sizeof(LuaBundle*)); //Write a pointer to this LuaBundle into the extra space of the new lua_State
+    luaL_openlibs(L);
+    for (LuaFunction* function : definedLuaFunctions)
+        lua_register(L,function->name,function->cfunction);
+    QDir::setCurrent(filedir);
+    lua_sethook(L,&luaHookFunction,LUA_MASKCOUNT,MELON_LUA_HOOK_INSTRUCTION_COUNT); 
+    if (luaL_dofile(L,fileName.data())==LUA_OK)
+    {
+        luaState = L;
+    }
+    else //Error loading script
+    {
+        printText(lua_tostring(L,-1));
+    }
+}
+
+void LuaConsoleDialog::onStop()
+{
+    if (bundle->getLuaState()) 
+        bundle->flagStop = true;
+}
+
+void LuaConsoleDialog::onPausePlay()
+{
+    bundle->flagPause = !bundle->flagPause;
+}
+
+void LuaConsoleDialog::onLuaUpdate()
+{
+    bundle->createLuaState();
+    bundle->luaUpdate();
+}
+
+//Gets Called once a frame
+void LuaBundle::luaUpdate()
+{
+    if (!luaState || flagPause) return;
+    if (lua_getglobal(luaState,"_Update")!=LUA_TFUNCTION)
+    {
+        printText("No \"_Update\" Function found, pausing script...");
+        flagPause = true;
+        return;
+    }
+    if (lua_pcall(luaState,0,0,0)!=0)
+    {
+        //Handel Errors
+        printText(lua_tostring(luaState,-1));
+        luaState = nullptr;
+    }
+}
+
+OverlayCanvas::OverlayCanvas(int x,int y,int width,int height,LuaCanvasTarget t)
+{
+    target = t;
+    buffer1 = new QImage(width,height,QImage::Format_ARGB32_Premultiplied);
+    buffer2 = new QImage(width,height,QImage::Format_ARGB32_Premultiplied);
+    buffer1->fill(0xffffff00); //initializes buffer with yellow pixels (probably should change this to transparent black pixels at some point...)
+    buffer2->fill(0xffffff00);
+    imageBuffer = buffer1;
+    displayBuffer = buffer2;
+    rectangle = QRect(x,y,width,height);
+    flipped = false;
+    GLTextureLoaded = false;
+}
+
+void OverlayCanvas::flip()
+{
+    if (imageBuffer == buffer1)
+    {
+        imageBuffer = buffer2;
+        displayBuffer = buffer1;
+    }
+    else
+    {
+        imageBuffer = buffer1;
+        displayBuffer = buffer2;
+    }
+    flipped = true;
+}
+
+void LuaBundle::luaResetOSD()
+{
+    for (auto lo = overlays->begin(); lo != overlays->end();)
+    {
+        OverlayCanvas& overlay = *lo;
+        overlay.GLTextureLoaded = false;
+        lo++;
+    }
+}
+
+//TODO: Organize lua functions into different named tables similar to bizhawk.
+/*--------------------------------------------------------------------------------------------------
+                            Start of lua function definitions
+--------------------------------------------------------------------------------------------------*/
+
+namespace luaDefinitions
+{
+
+#define AddLuaFunction(functPointer,name)LuaFunction name(functPointer,#name,&definedLuaFunctions)
+
+int lua_MelonPrint(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    const char* string = luaL_checkstring(L,1);
+    bundle->printText((QString)string);
+    return 0;
+}
+AddLuaFunction(lua_MelonPrint,print);
+
+int lua_MelonClear(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    bundle->getluaDialog()->console->clear();
+    return 0;
+}
+AddLuaFunction(lua_MelonClear,MelonClear);
+
+enum ramInfo_ByteType
+{
+    ramInfo_OneByte = 1, 
+    ramInfo_TwoBytes = 2, 
+    ramInfo_FourBytes = 4
+};
+
+melonDS::u32 GetMainRAMValueU(const melonDS::u32& addr, const ramInfo_ByteType& byteType,LuaBundle* bundle)
+{
+
+    melonDS::NDS* nds = bundle->getEmuInstance()->getNDS();
+    switch (byteType)
+    {
+    case ramInfo_OneByte:
+        return *(melonDS::u8*)(nds->MainRAM + (addr&nds->MainRAMMask));
+    case ramInfo_TwoBytes:
+        return *(melonDS::u16*)(nds->MainRAM + (addr&nds->MainRAMMask));
+    case ramInfo_FourBytes:
+        return *(melonDS::u32*)(nds->MainRAM + (addr&nds->MainRAMMask));
+    default:
+        return 0;
+    }
+
+}
+
+melonDS::s32 GetMainRAMValueS(const melonDS::u32& addr, const ramInfo_ByteType& byteType,LuaBundle* bundle)
+{
+    melonDS::NDS* nds = bundle->getEmuInstance()->getNDS();
+    switch (byteType)
+    {
+    case ramInfo_OneByte:
+        return *(melonDS::s8*)(nds->MainRAM + (addr&nds->MainRAMMask));
+    case ramInfo_TwoBytes:
+        return *(melonDS::s16*)(nds->MainRAM + (addr&nds->MainRAMMask));
+    case ramInfo_FourBytes:
+        return *(melonDS::s32*)(nds->MainRAM + (addr&nds->MainRAMMask));
+    default:
+        return 0;
+    }
+}
+
+int Lua_ReadDatau(lua_State* L,ramInfo_ByteType byteType) 
+{   
+    LuaBundle* bundle = get_bundle(L);
+    melonDS::u32 address = luaL_checkinteger(L,1);
+    melonDS::u32 value = GetMainRAMValueU(address,byteType,bundle);
+    lua_pushinteger(L, value);
+    return 1;
+}
+
+int Lua_ReadDatas(lua_State* L,ramInfo_ByteType byteType)
+{
+    LuaBundle* bundle = get_bundle(L);
+    melonDS::u32 address = luaL_checkinteger(L,1);
+    melonDS::s32 value = GetMainRAMValueS(address,byteType,bundle);
+    lua_pushinteger(L, value);
+    return 1;
+}
+
+int Lua_Readu8(lua_State* L)
+{
+    return Lua_ReadDatau(L,ramInfo_OneByte);
+}
+AddLuaFunction(Lua_Readu8,Readu8);
+
+int Lua_Readu16(lua_State* L)
+{
+    return Lua_ReadDatau(L,ramInfo_TwoBytes);
+}
+AddLuaFunction(Lua_Readu16,Readu16);
+
+int Lua_Readu32(lua_State* L)
+{
+    return Lua_ReadDatau(L,ramInfo_FourBytes);
+}
+AddLuaFunction(Lua_Readu32,Readu32);
+
+int Lua_Reads8(lua_State* L)
+{
+    return Lua_ReadDatas(L,ramInfo_OneByte);
+}
+AddLuaFunction(Lua_Reads8,Reads8);
+
+int Lua_Reads16(lua_State* L)
+{
+    return Lua_ReadDatas(L,ramInfo_TwoBytes);
+}
+AddLuaFunction(Lua_Reads16,Reads16);
+
+int Lua_Reads32(lua_State* L)
+{
+    return Lua_ReadDatas(L,ramInfo_FourBytes);
+}
+AddLuaFunction(Lua_Reads32,Reads32);
+
+int Lua_NDSTapDown(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    int x = luaL_checkinteger(L,1);
+    int y = luaL_checkinteger(L,2);
+    bundle->getEmuInstance()->touchScreen(x,y);
+    return 0;
+}
+AddLuaFunction(Lua_NDSTapDown,NDSTapDown);
+
+int Lua_NDSTapUp(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    bundle->getEmuInstance()->releaseScreen();
+    return 0;
+}
+AddLuaFunction(Lua_NDSTapUp,NDSTapUp);
+
+int Lua_StateSave(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    const char* filename = luaL_checkstring(L,1);
+    bundle->getluaDialog()->onLuaSaveState((QString)filename);
+    return 0;
+}
+AddLuaFunction(Lua_StateSave,StateSave);
+
+int Lua_StateLoad(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    const char* filename = luaL_checkstring(L,1);
+
+    bundle->getluaDialog()->onLuaLoadState((QString)filename);
+    return 0;
+}
+AddLuaFunction(Lua_StateLoad,StateLoad);
+
+int Lua_getMouse(lua_State* L)
+{
+    Qt::MouseButtons btns = QGuiApplication::mouseButtons();
+    LuaBundle* bundle = get_bundle(L);
+    QPoint pos = bundle->getEmuInstance()->getMainWindow()->panel->mapFromGlobal(QCursor::pos(QGuiApplication::primaryScreen()));
+    const char* keys[6] = {"Left","Middle","Right","XButton1","XButton2","Wheel"};
+    bool vals[6] =
+    {
+        btns.testFlag(Qt::LeftButton),
+        btns.testFlag(Qt::MiddleButton),
+        btns.testFlag(Qt::RightButton),
+        btns.testFlag(Qt::XButton1),
+        btns.testFlag(Qt::XButton2),
+        false //TODO: add mouse wheel support
+    };
+    lua_createtable(L, 0, 8);
+    lua_pushinteger(L, pos.x());
+    lua_setfield(L, -2, "X");
+    lua_pushinteger(L, pos.y());
+    lua_setfield(L, -2, "Y");
+    for (int i=0;i<6;i++)
+    {
+        lua_pushboolean(L,vals[i]);
+        lua_setfield(L,-2,keys[i]);
+    }
+    return 1;//returns table describing the current pos and state of the mouse
+}
+AddLuaFunction(Lua_getMouse,GetMouse);
+
+int Lua_HeldKeys(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    lua_createtable(L,0,bundle->getEmuInstance()->heldKeys.size());
+    for (int key : bundle->getEmuInstance()->heldKeys)
+    {
+        lua_pushboolean(L,true);
+        lua_seti(L,-2,key);
+    }
+    return 1;//returns table of currently held keys.
+}
+AddLuaFunction(Lua_HeldKeys,HeldKeys);
+
+int Lua_PushShapeData(lua_State* L)
+{
+    size_t len;
+    //Pointer to string data on the lua Stack
+    const char* bytes = luaL_checklstring(L,1,&len);
+    if (len!=112){
+        luaL_error(L, "BuildShape Error, given shapeString is not 112 bytes in len");
+        return 1;
+    }
+    //Need to copy bytes from the lua Stack into local memory
+    std::string shapeString = std::string(bytes,len);
+    //Cast from 112 byte string into a 112 byte ShapeData2D UBO struct
+    Plugins::ShapeData2D shape = *(Plugins::ShapeData2D*)shapeString.c_str();
+    int index = Plugins::PushShape(shape);
+    lua_pushinteger(L,index);
+    return 1;
+}
+AddLuaFunction(Lua_PushShapeData,PushShapeData);
+
+int Lua_GetCurrentAspectRatio(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    Plugins::Plugin* myPlugin = bundle->getEmuInstance()->plugin;
+    float aspectRatio = myPlugin->GetCurrentAspectRatio();
+    lua_pushnumber(L,aspectRatio);
+    return 1;
+}
+AddLuaFunction(Lua_GetCurrentAspectRatio,GetCurrentAspectRatio);
+
+int Lua_SetShapes(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    std::vector<int> shapes;
+    int shapeNum = 1;
+    lua_pushnumber(L,shapeNum++);
+    lua_gettable(L,-2);
+    //Pull list of shape index from lua
+    while(lua_isinteger(L,-1)){
+        shapes.push_back(lua_tointeger(L,-1));
+        lua_pop(L,1);
+        lua_pushnumber(L,shapeNum++);
+        lua_gettable(L,-2);
+    }
+    lua_pop(L,2);
+    int isgood = Plugins::SetShapes(shapes);
+    lua_pushinteger(L,isgood);
+    return 1;//Returns succsess of SetShapes
+}
+AddLuaFunction(Lua_SetShapes,SetShapes);
+
+int Lua_SetGameScene(lua_State* L)
+{
+    int gamescene = luaL_checkinteger(L,1);
+    Plugins::setLuaGameScene(gamescene);
+    return 0;
+}
+AddLuaFunction(Lua_SetGameScene,SetGameScene);
+
+int Lua_getJoyStick(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    int axisNum = luaL_checknumber(L,1);
+    int val = bundle->getEmuInstance()->getJoyStickAxis(axisNum);
+    lua_pushinteger(L,val);
+    return 1;
+}
+AddLuaFunction(Lua_getJoyStick,GetJoyStick);
+
+/*--------------------------------------------------------------------------------------------------
+                            Front-end lua function definitions --Commented out for now...
+--------------------------------------------------------------------------------------------------*/
+//TODO: Lua Colors 
+
+/*
+
+//MakeCanvas(int x,int y,int width,int height,[int target,topScreen=0,bottomScreen=1,OSD(default)>=2)],[bool active = true])
+int Lua_MakeCanvas(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    int x = luaL_checknumber(L,1);
+    int y = luaL_checknumber(L,2);
+    int w = luaL_checknumber(L,3);
+    int h = luaL_checknumber(L,4);
+    int t = luaL_optinteger(L,5,2);
+    bool a = 0 != luaL_optinteger(L,6,1);
+    
+    OverlayCanvas canvas(x,y,w,h,(LuaCanvasTarget)t);
+    canvas.isActive = a;
+    lua_pushinteger(L,bundle->overlays->size());
+    bundle->overlays->push_back(canvas);
+    return 1; //returns index of the new overlay
+}
+AddLuaFunction(Lua_MakeCanvas,MakeCanvas);
+
+int Lua_SetCanvas(lua_State* L) //SetCanvas(int index)
+{
+    LuaBundle* bundle = get_bundle(L);
+    int index = luaL_checknumber(L,1);
+
+    bundle->luaCanvas = &bundle->overlays->at(index);
+    return 0;
+}
+AddLuaFunction(Lua_SetCanvas,SetCanvas);
+int Lua_ClearOverlay(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    bundle->luaCanvas->imageBuffer->fill(0x00000000);
+    return 0;
+}
+AddLuaFunction(Lua_ClearOverlay,ClearOverlay);
+
+int Lua_Flip(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    bundle->luaCanvas->flip();
+    return 0;
+}
+AddLuaFunction(Lua_Flip,Flip);
+
+//Text(int x, int y, string message, [u32 color = 'black'], [int fontsize = 9], [string fontfamily = Helvetica])
+int Lua_text(lua_State* L) 
+{
+    LuaBundle* bundle = get_bundle(L);
+    int x = luaL_checknumber(L,1);
+    int y = luaL_checknumber(L,2);
+    const char* message = luaL_checklstring(L,3,NULL);
+    melonDS::u32 color = luaL_optnumber(L,4,0x00000000);
+    const char* FontFamily = luaL_optlstring(L,6,"Helvetica",NULL);
+    int size = luaL_optnumber(L,5,9);
+
+    QPainter painter(bundle->luaCanvas->imageBuffer);
+    QFont font(FontFamily,size,0,false);
+    //font.setStyleStrategy(QFont::NoAntialias);
+    //font.setLetterSpacing(QFont::AbsoluteSpacing,-1);
+    painter.setFont(font);
+    painter.setPen(color);
+    painter.drawText(x,y,message);
+    return 0;
+}
+AddLuaFunction(Lua_text,Text);
+
+int Lua_line(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    int x1 = luaL_checknumber(L,1);
+    int y1 = luaL_checknumber(L,2);
+    int x2 = luaL_checknumber(L,3);
+    int y2 = luaL_checknumber(L,4);
+    melonDS::u32 color = luaL_checknumber(L,5);
+
+    QPainter painter(bundle->luaCanvas->imageBuffer);
+    painter.setPen(color);
+    painter.drawLine(x1,y1,x2,y2);
+    return 0;
+}
+AddLuaFunction(Lua_line,Line);
+
+int Lua_rect(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    melonDS::u32 color = luaL_checknumber(L,5);
+    int x = luaL_checknumber(L,1);
+    int y = luaL_checknumber(L,2);
+    int width = luaL_checknumber(L,3);
+    int height = luaL_checknumber(L,4);
+
+    QPainter painter(bundle->luaCanvas->imageBuffer);
+    painter.setPen(color);
+    painter.drawRect(x,y,width,height);
+    return 0;
+}
+AddLuaFunction(Lua_rect,Rect);
+
+int Lua_fillrect(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    melonDS::u32 color = luaL_checknumber(L,5);
+    int x = luaL_checknumber(L,1);
+    int y = luaL_checknumber(L,2);
+    int width = luaL_checknumber(L,3);
+    int height = luaL_checknumber(L,4);
+
+    QPainter painter(bundle->luaCanvas->imageBuffer);
+    painter.setPen(color);
+    painter.fillRect(x,y,width,height,color);
+    return 0;
+}
+AddLuaFunction(Lua_fillrect,FillRect);
+
+int Lua_Ellipse(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    melonDS::u32 color = luaL_checknumber(L,5);
+    int x = luaL_checknumber(L,1);
+    int y = luaL_checknumber(L,2);
+    int width = luaL_checknumber(L,3);
+    int height = luaL_checknumber(L,4);
+
+    QPainter painter(bundle->luaCanvas->imageBuffer);
+    painter.setPen(color);
+    painter.drawEllipse(x,y,width,height);
+    return 0;
+}
+AddLuaFunction(Lua_Ellipse,Ellipse);
+
+int Lua_keystrokes(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    lua_createtable(L,0,bundle->getEmuInstance()->keyStrokes.size());
+    for (int i = 0; i<bundle->getEmuInstance()->keyStrokes.size(); i++)
+    {
+        lua_pushinteger(L,bundle->getEmuInstance()->keyStrokes.at(i));
+        lua_seti(L,-2,i);
+    }
+    bundle->getEmuInstance()->keyStrokes.clear();
+    return 1;
+}
+AddLuaFunction(Lua_keystrokes,Keys);
+
+//DrawImage(string path, int x, int y,[int source x=0], [int source y=0], [int source w=-1],[int source h=-1])
+int Lua_drawImage(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    const char* path = luaL_checklstring(L,1,NULL);
+    int x = luaL_checkinteger(L,2);
+    int y = luaL_checkinteger(L,3);
+    int sx = luaL_optinteger(L,4,0);
+    int sy = luaL_optinteger(L,5,0);
+    int sw = luaL_optinteger(L,6,-1);
+    int sh = luaL_optinteger(L,7,-1);
+
+    QPainter painter(bundle->luaCanvas->imageBuffer);
+    QImage image;
+    if (bundle->imageHash->contains(path))
+    {
+        image=(*bundle->imageHash)[path];
+    }
+    else
+    {
+        image=QImage((QString)path);
+        (*bundle->imageHash)[path] = image;
+    }
+    painter.drawImage(x,y,image,sx,sy,sw,sh);
+    return 0;
+}
+AddLuaFunction(Lua_drawImage,DrawImage);
+
+int Lua_clearImageHash(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    bundle->imageHash->clear();
+    return 0;
+}
+AddLuaFunction(Lua_clearImageHash,ClearHash);
+
+int Lua_getJoy(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    melonDS::u32 buttonMask=bundle->getEmuInstance()->getInputMask();//current button state.
+    const char* keys[12] =
+    {//Buttons in order of mask.
+        "A","B","Select","Start",
+        "Right","Left","Up","Down",
+        "R","L","X","Y"
+    };
+    lua_createtable(L, 0, 12);
+    for (melonDS::u32 i=0;i<12;i++)
+    {
+        lua_pushboolean(L,0 >= (buttonMask&(1<<i)));
+        lua_setfield(L,-2,keys[i]);
+    }
+    return 1;
+}
+AddLuaFunction(Lua_getJoy,GetJoy);
+
+int Lua_getJoyStick(lua_State* L)
+{
+    LuaBundle* bundle = get_bundle(L);
+    int axisNum = luaL_checknumber(L,1);
+    int val = bundle->getEmuInstance()->getJoyStickAxis(axisNum);
+    lua_pushinteger(L,val);
+    return 1;
+}
+AddLuaFunction(Lua_getJoyStick,GetJoyStick);
+*/
+}

--- a/src/frontend/qt_sdl/LuaMain.h
+++ b/src/frontend/qt_sdl/LuaMain.h
@@ -1,0 +1,116 @@
+#ifndef LUAMAIN_H
+#define LUAMAIN_H
+#include <QDialog>
+#include <QPlainTextEdit>
+#include <QFileInfo>
+#include <lua.hpp>
+#include "EmuInstance.h"
+
+class LuaConsole: public QPlainTextEdit
+{
+    Q_OBJECT
+public:
+    LuaConsole(QWidget* parent=nullptr);
+public slots:
+    void onGetText(const QString& string);
+    void onClear();
+};
+
+class LuaBundle;
+
+class LuaConsoleDialog: public QDialog
+{
+    Q_OBJECT
+public:
+    LuaConsoleDialog(QWidget* parent);
+    LuaBundle* getLuaBundle(){return bundle;};
+    LuaConsole* console;
+    QFileInfo currentScript;
+    QPushButton* buttonOpenScript;
+    QPushButton* buttonStartStop;
+    QPushButton* buttonPausePlay;
+    QScrollBar* bar;
+    bool flagClosed;
+    void onLuaSaveState(QString);
+    void onLuaLoadState(QString);
+protected:
+    void closeEvent(QCloseEvent *event) override;
+    LuaBundle* bundle;
+signals:
+    void signalNewLua();
+    void signalClosing();
+    void signalLuaSaveState(const QString&);
+    void signalLuaLoadState(const QString&);
+public slots:
+    //void onStartStop();
+    void onOpenScript();
+    void onStop();
+    void onPausePlay();
+    void onLuaUpdate();
+};
+
+//Based on ScreenLayout::GetScreenTransforms
+enum LuaCanvasTarget 
+{
+    canvasTarget_TopScreen = 0,
+    canvasTarget_BottomScreen = 1,
+    canvasTarget_OSD = 2 //Used for drawing to OSD / non-screen target
+};
+
+struct OverlayCanvas
+{
+    QImage* imageBuffer; // buffer edited by luascript
+    QImage* displayBuffer; //buffer displayed on screen
+    QImage* buffer1;
+    QImage* buffer2;
+    QRect rectangle;
+    LuaCanvasTarget target = canvasTarget_OSD;
+    bool isActive = true; // only active overlays are drawn
+    unsigned int GLTexture; // used by GL rendering
+    bool GLTextureLoaded;
+    OverlayCanvas(int x, int y,int w, int h, LuaCanvasTarget target = canvasTarget_OSD);
+    void flip();//used to swap buffers / update canvas
+    bool flipped; //used to signal update to graphics.
+};
+
+typedef int(*luaFunctionPointer)(lua_State*);
+struct LuaFunction
+{
+    luaFunctionPointer cfunction;
+    const char* name;
+    LuaFunction(luaFunctionPointer,const char*,std::vector<LuaFunction*>*);
+};
+
+class LuaBundle
+{
+    EmuInstance* emuInstance;
+    EmuThread* emuThread;
+    LuaConsoleDialog* luaDialog;
+    lua_State* luaState = nullptr;
+    int basketID;
+
+    void luaResetOSD();
+    void luaPrint(QString string);
+    void luaClearConsole();  
+    
+    OverlayCanvas* currentCanvas = nullptr;
+    friend class LuaConsolDialog;
+public:
+    LuaBundle(LuaConsoleDialog* dialog,EmuInstance* inst);
+    lua_State* getLuaState(){return luaState;};
+    EmuThread* getEmuThread(){return emuThread;};
+    EmuInstance* getEmuInstance(){return emuInstance;};
+    LuaConsoleDialog* getluaDialog(){return luaDialog;};
+    void printText(QString string);
+    void createLuaState();
+    void luaUpdate();
+    bool flagPause = false;
+    bool flagStop = false;
+    bool flagNewLua = false;
+    OverlayCanvas* luaCanvas = nullptr;
+    std::vector<OverlayCanvas>* overlays;
+    QHash<QString, QImage>* imageHash;
+
+};
+
+#endif

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -88,6 +88,8 @@
 #include "Window.h"
 #include "AboutDialog.h"
 
+#include "LuaMain.h"
+
 using namespace melonDS;
 
 
@@ -429,6 +431,11 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
 
             actDateTime = menu->addAction("Date and time");
             connect(actDateTime, &QAction::triggered, this, &MainWindow::onOpenDateTime);
+
+            menu->addSeparator();
+
+            actLuaScript = menu->addAction("Lua Script");
+            connect(actLuaScript,&QAction::triggered,this,&MainWindow::onOpenLuaScript);
 
             menu->addSeparator();
 
@@ -1586,6 +1593,13 @@ void MainWindow::onEjectGBACart()
     updateCartInserted(true);
 }
 
+void MainWindow::onLuaSaveState(const QString& filename)
+{
+    emuThread->emuPause();
+    emuInstance->saveState(filename.toStdString());
+    emuThread->emuUnpause();
+}
+
 void MainWindow::onSaveState()
 {
     int slot = ((QAction*)sender())->data().toInt();
@@ -1619,6 +1633,13 @@ void MainWindow::onSaveState()
     {
         emuInstance->osdAddMessage(0xFFA0A0, "State save failed");
     }
+}
+
+void MainWindow::onLuaLoadState(const QString& filename)
+{
+    emuThread->emuPause();
+    emuInstance->loadState(filename.toStdString());
+    emuThread->emuUnpause();
 }
 
 void MainWindow::onLoadState()
@@ -1760,6 +1781,22 @@ void MainWindow::onOpenDateTime()
 void MainWindow::onOpenPowerManagement()
 {
     PowerManagementDialog* dlg = PowerManagementDialog::openDlg(this);
+}
+
+void MainWindow::onOpenLuaScript()
+{
+    if (luaDialog && luaDialog->flagClosed)
+    {
+        delete luaDialog;
+        luaDialog = nullptr;
+    }
+    if (luaDialog)
+        return;
+    luaDialog = new LuaConsoleDialog(this);
+    luaDialog->show();
+    connect(emuThread,&EmuThread::signalLuaUpdate,luaDialog,&LuaConsoleDialog::onLuaUpdate);
+    connect(luaDialog,&LuaConsoleDialog::signalLuaSaveState,this,&MainWindow::onLuaSaveState);
+    connect(luaDialog,&LuaConsoleDialog::signalLuaLoadState,this,&MainWindow::onLuaLoadState);
 }
 
 void MainWindow::onEnableCheats(bool checked)

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -41,6 +41,7 @@
 
 class EmuInstance;
 class EmuThread;
+class LuaConsoleDialog;
 
 const int kMaxRecentROMs = 10;
 
@@ -111,6 +112,9 @@ public:
 
     EmuInstance* getEmuInstance() { return emuInstance; }
     Config::Table& getWindowConfig() { return windowCfg; }
+
+    LuaConsoleDialog* getLuaDialog() { return luaDialog; }
+
     int getWindowID() { return windowID; }
 
     bool winHasMenu() { return hasMenu; }
@@ -170,7 +174,9 @@ private slots:
     void onInsertGBACart();
     void onInsertGBAAddon();
     void onEjectGBACart();
+    void onLuaSaveState(const QString& filename);
     void onSaveState();
+    void onLuaLoadState(const QString& filename);
     void onLoadState();
     void onUndoStateLoad();
     void onImportSavefile();
@@ -181,6 +187,7 @@ private slots:
     void onStop();
     void onFrameStep();
     void onOpenPowerManagement();
+    void onOpenLuaScript();
     void onOpenDateTime();
     void onEnableCheats(bool checked);
     void onSetupCheats();
@@ -279,6 +286,7 @@ private:
 
     EmuInstance* emuInstance;
     EmuThread* emuThread;
+    LuaConsoleDialog* luaDialog=nullptr;
 
     Config::Table& globalCfg;
     Config::Table& localCfg;
@@ -328,6 +336,7 @@ public:
 #ifdef __APPLE__
     QAction* actPreferences;
 #endif
+    QAction* actLuaScript;
     QAction* actInputConfig;
     QAction* actVideoSettings;
     QAction* actCameraSettings;

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -345,6 +345,9 @@ public:
     bool MainRAMState[0xFFFFFF];
 
     void ramSearch(melonDS::NDS* nds, u32 HotkeyPress);
+
+    float GetCurrentAspectRatio() {return AspectRatio;}
+    
 protected:
     std::map<GLuint, GLuint[20]> CompGpuLoc{};
     std::map<GLuint, GLuint> CompUboLoc{};

--- a/src/plugins/PluginManager.cpp
+++ b/src/plugins/PluginManager.cpp
@@ -4,12 +4,14 @@
 #include "PluginKingdomHeartsReCoded.h"
 #include "PluginHarvestMoonDsCute.h"
 #include "PluginMetroidPrimeHunters.h"
+#include "PluginTemplate.h"
 
 #define LOAD_PLUGINS \
     LOAD_PLUGIN(PluginKingdomHeartsDays) \
     LOAD_PLUGIN(PluginKingdomHeartsReCoded) \
     LOAD_PLUGIN(PluginHarvestMoonDsCute) \
-    LOAD_PLUGIN(PluginMetroidPrimeHunters)
+    LOAD_PLUGIN(PluginMetroidPrimeHunters) \
+    LOAD_PLUGIN(PluginTemplate)
 
 namespace Plugins
 {

--- a/src/plugins/PluginManager.cpp
+++ b/src/plugins/PluginManager.cpp
@@ -4,14 +4,14 @@
 #include "PluginKingdomHeartsReCoded.h"
 #include "PluginHarvestMoonDsCute.h"
 #include "PluginMetroidPrimeHunters.h"
-#include "PluginTemplate.h"
+//#include "PluginTemplate.h"
 
 #define LOAD_PLUGINS \
     LOAD_PLUGIN(PluginKingdomHeartsDays) \
     LOAD_PLUGIN(PluginKingdomHeartsReCoded) \
     LOAD_PLUGIN(PluginHarvestMoonDsCute) \
     LOAD_PLUGIN(PluginMetroidPrimeHunters) \
-    LOAD_PLUGIN(PluginTemplate)
+//  LOAD_PLUGIN(PluginTemplate)
 
 namespace Plugins
 {

--- a/src/plugins/PluginManager.cpp
+++ b/src/plugins/PluginManager.cpp
@@ -4,6 +4,7 @@
 #include "PluginKingdomHeartsReCoded.h"
 #include "PluginHarvestMoonDsCute.h"
 #include "PluginMetroidPrimeHunters.h"
+#include "PluginTemplateLua.h"
 //#include "PluginTemplate.h"
 
 #define LOAD_PLUGINS \
@@ -11,6 +12,7 @@
     LOAD_PLUGIN(PluginKingdomHeartsReCoded) \
     LOAD_PLUGIN(PluginHarvestMoonDsCute) \
     LOAD_PLUGIN(PluginMetroidPrimeHunters) \
+    LOAD_PLUGIN(PluginTemplateLua) \
 //  LOAD_PLUGIN(PluginTemplate)
 
 namespace Plugins

--- a/src/plugins/PluginTemplate.h
+++ b/src/plugins/PluginTemplate.h
@@ -16,8 +16,8 @@ public:
     static u32 usGamecode;
     static u32 euGamecode;
     static u32 jpGamecode;
-    //static bool isCart(u32 gameCode) {return gameCode == usGamecode || gameCode == euGamecode || gameCode == jpGamecode;};
-    static bool isCart(u32 gameCode) {return true};
+    static bool isCart(u32 gameCode) {return gameCode == usGamecode || gameCode == euGamecode || gameCode == jpGamecode;};
+    //static bool isCart(u32 gameCode) {return true};
     bool isUsaCart()        { return GameCode == usGamecode; };
     bool isEuropeCart()     { return GameCode == euGamecode; };
     bool isJapanCart()      { return GameCode == jpGamecode; };

--- a/src/plugins/PluginTemplate.h
+++ b/src/plugins/PluginTemplate.h
@@ -1,5 +1,5 @@
-#ifndef PLUGIN_METROID_PRIME_HUNTERS_H
-#define PLUGIN_METROID_PRIME_HUNTERS_H
+#ifndef PLUGIN_TEMPLATE_H
+#define PLUGIN_TEMPLATE_H
 
 #include "Plugin.h"
 #include "../NDS.h"
@@ -16,7 +16,8 @@ public:
     static u32 usGamecode;
     static u32 euGamecode;
     static u32 jpGamecode;
-    static bool isCart(u32 gameCode) {return gameCode == usGamecode || gameCode == euGamecode || gameCode == jpGamecode;};
+    //static bool isCart(u32 gameCode) {return gameCode == usGamecode || gameCode == euGamecode || gameCode == jpGamecode;};
+    static bool isCart(u32 gameCode) {return true};
     bool isUsaCart()        { return GameCode == usGamecode; };
     bool isEuropeCart()     { return GameCode == euGamecode; };
     bool isJapanCart()      { return GameCode == jpGamecode; };

--- a/src/plugins/PluginTemplateLua.cpp
+++ b/src/plugins/PluginTemplateLua.cpp
@@ -1,0 +1,96 @@
+#include "PluginTemplateLua.h"
+
+#define ASPECT_RATIO_ADDRESS_US      0
+#define ASPECT_RATIO_ADDRESS_EU      0
+#define ASPECT_RATIO_ADDRESS_JP      0
+
+namespace Plugins
+{
+
+u32 PluginTemplateLua::usGamecode = 0;
+u32 PluginTemplateLua::euGamecode = 0;
+u32 PluginTemplateLua::jpGamecode = 0;
+
+#define getAnyByCart(usAddress,euAddress,jpAddress) (isUsaCart() ? (usAddress) : (isEuropeCart() ? (euAddress) : (jpAddress)))
+
+PluginTemplateLua::PluginTemplateLua(u32 gameCode)
+{
+    GameCode = gameCode;
+
+    hudToggle();
+}
+
+
+static int luaGameScene;
+
+int PluginTemplateLua::detectGameScene()
+{
+    if (nds == nullptr)
+    {
+        return GameScene;
+    }
+
+    return luaGameScene;
+}
+
+static std::vector<ShapeData2D> BuiltShapes;
+//Push shape data onto the global BuiltShapes array
+int PushShape(ShapeData2D shape){
+    BuiltShapes.push_back(shape);
+    return BuiltShapes.size()-1;
+}
+
+static std::vector<ShapeData2D> CurrentShapes;
+int SetShapes(std::vector<int> shapes){
+    CurrentShapes.clear();
+    for (int const& index: shapes){
+        if (index<BuiltShapes.size() and index>=0){
+            CurrentShapes.push_back(BuiltShapes[index]);
+        } else {
+            CurrentShapes.clear();
+            printf("Shape Index not found..."); // This can happen if the lua script uses an invalid index by mistake 
+            //TODO: throw error to LUA console...
+            return -1;
+        }
+    }
+    return 0;
+}
+
+void setLuaGameScene(int gamescene){
+    luaGameScene = gamescene;   
+}
+
+int PluginTemplateLua::renderer_gameSceneState(){
+    int gamescene = luaGameScene;
+    return gamescene;
+}
+
+std::vector<ShapeData2D> PluginTemplateLua::renderer_2DShapes() {    
+    std::vector<ShapeData2D> shapes = CurrentShapes;
+    return shapes;
+}
+
+int PluginTemplateLua::renderer_screenLayout() {
+    return screenLayout_Top;
+};
+
+int PluginTemplateLua::renderer_brightnessMode() {
+    return brightnessMode_TopScreen;
+}
+
+bool PluginTemplateLua::renderer_showOriginalUI() {
+    return false;
+}
+
+void PluginTemplateLua::applyAddonKeysToInputMaskOrTouchControls(u32* InputMask, u16* touchX, u16* touchY, bool* isTouching, u32* HotkeyMask, u32* HotkeyPress) {
+    
+}
+void PluginTemplateLua::applyTouchKeyMaskToTouchControls(u16* touchX, u16* touchY, bool* isTouching, u32 TouchKeyMask) {
+    _superApplyTouchKeyMaskToTouchControls(touchX, touchY, isTouching, TouchKeyMask, 3, true);
+}
+
+u32 PluginTemplateLua::getAspectRatioAddress() {
+    return getAnyByCart(ASPECT_RATIO_ADDRESS_US, ASPECT_RATIO_ADDRESS_EU, ASPECT_RATIO_ADDRESS_JP);
+}
+
+}

--- a/src/plugins/PluginTemplateLua.h
+++ b/src/plugins/PluginTemplateLua.h
@@ -1,0 +1,51 @@
+
+#ifndef PLUGIN_TEMPLATE_H
+#define PLUGIN_TEMPLATE_H
+
+#include "Plugin.h"
+#include "../NDS.h"
+
+namespace Plugins
+{
+using namespace melonDS;
+
+int PushShape(ShapeData2D shape);
+int SetShapes(std::vector<int> shapes);
+void setLuaGameScene(int gamescene);
+
+class PluginTemplateLua : public Plugin
+{
+public:
+    PluginTemplateLua(u32 gameCode);
+    static u32 usGamecode;
+    static u32 euGamecode;
+    static u32 jpGamecode;
+    static bool isCart(u32 gameCode) {return true;};
+    bool isUsaCart()        { return GameCode == usGamecode; };
+    bool isEuropeCart()     { return GameCode == euGamecode; };
+    bool isJapanCart()      { return GameCode == jpGamecode; };
+
+    std::string assetsFolder() {
+        return std::to_string(GameCode);
+    }
+    int renderer_gameSceneState();
+    std::vector<ShapeData2D> renderer_2DShapes();
+    int renderer_screenLayout();
+    int renderer_brightnessMode();
+    bool renderer_showOriginalUI();
+
+    void applyAddonKeysToInputMaskOrTouchControls(u32* InputMask, u16* touchX, u16* touchY, bool* isTouching, u32* HotkeyMask, u32* HotkeyPress);
+    void applyTouchKeyMaskToTouchControls(u16* touchX, u16* touchY, bool* isTouching, u32 TouchKeyMask);
+
+    const char* getGameSceneName() {
+        return "";
+    }
+
+    u32 getAspectRatioAddress();
+
+private:
+    int detectGameScene();
+};
+}
+
+#endif

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -18,7 +18,8 @@
 		{
 			"name": "libslirp",
 			"platform": "linux"
-		}
+		},
+		"lua"
 	],
 	"features": {
 		"qt6": {


### PR DESCRIPTION
I ended up re-writing the ShapeBuilder2D class entirely in the lua scripting language. This allows for the syntax of the new lua plugins to match closer to the syntax of the current c++ plugins, and made managing the lua stack MUCH simpler. I plan to re-write other parts of the plugin engine in lua, with the end goal being to eventually re-implement the current c++ plugins into lua plugins. 

Here is a preview of the new syntax for lua plugins:

```lua
--lua file that contains the ShapeBuilder2D class
dofile "MelonMixShapes.lua"

local hudScale = 5
local aspectRatio = GetCurrentAspectRatio()

local shapeData_A = ShapeBuilder2D:square()
    :fromBottomScreen()
    :fromPosition(0,0)
    :withSize(256,192)
    :placeAtCorner(_corner.TopLeft)
    :sourceScale(1.5)
    :hudScale(hudScale)
    :build(1)

local shapeData_B = ShapeBuilder2D:square()
    :fromPosition(0,0)
    :withSize(256,192)
    :placeAtCorner(_corner.TopLeft)
    :sourceScale(0.5)
    :fadeBorderSize(0,0,2.5,2.5)
    :opacity(0.66)
    :hudScale(hudScale)
    :build(1)

local ScreenShape = PushShapeData(shapeData_A:bytes())
local MiniMapShape = PushShapeData(shapeData_B:bytes())

-- Set current shapes that should be loaded
SetShapes{MiniMapShape,ScreenShape}

--Update Game scene to signal the shader to update
SetGameScene(3)
local miniMapIsup = true
```

Also apologies for taking such a long break from working on this, (Health Issues :sweat: ) 