### PR TITLE
Fixed Fx keys sometimes causing MelonMix to crash

### DIFF
--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -444,7 +444,12 @@ void EmuInstance::onKeyPress(QKeyEvent* event)
 
 void EmuInstance::onKeyRelease(QKeyEvent* event)
 {
-    heldKeys.erase(std::find(heldKeys.begin(),heldKeys.end(),event->key()));
+    //If the released key is in heldKeys, remove it from heldKeys.
+    auto iterator = std::find(heldKeys.begin(),heldKeys.end(),event->key());
+    if (iterator != heldKeys.end()) {
+        heldKeys.erase(iterator);
+    }
+
     int keyHK = getEventKeyVal(event);
     int keyKP = keyHK;
     if (event->modifiers() != Qt::KeypadModifier)


### PR DESCRIPTION
Bold of me to assume that `onKeyRelease()` would only ever be called if the corresponding `onKeyPress()` was called previously....

Something about the QAction of loading a save state being triggered by a shortcut key,  seems to prevent `EmuInstance::onKeyPress()` from ever being called... but like only sometimes...

Probably for the best to just properly handle the edge case rather then assuming it won't happen.