### PR TITLE
Fix: Add lua to dependencies for macOS brew install

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -56,7 +56,7 @@ If everything went well, KH Melon Mix should now be in the `build` folder. For d
 
 ## macOS
 1. Install the [Homebrew Package Manager](https://brew.sh)
-2. Install dependencies: `brew install git pkg-config cmake sdl2 qt@6 libarchive enet zstd faad2 flac`
+2. Install dependencies: `brew install git pkg-config cmake sdl2 qt@6 libarchive enet zstd faad2 flac lua`
 3. Download the KH Melon Mix repository and prepare:
    ```zsh
    git clone https://github.com/vitor251093/KHMelonMix


### PR DESCRIPTION
Noticed while setting up my environment while working on #442.

## Issue

Following BUILD.md steps for macOS gave me errors related to Lua not being found.

## Solution

Add `lua` to `brew install` line. Convenience for future contributors developing on Mac.

## Tested

Builds successfully on macOS 15.7.1.