### PR TITLE
Fix: Memory leaks in texture replacement system

### DIFF
--- a/src/GPU3D_Texcache.h
+++ b/src/GPU3D_Texcache.h
@@ -391,21 +391,30 @@ public:
 
             TexArrayEntry& storagePlace = it->second.Texture;
 
+            u32 currentIdx = storagePlace.CurrentIndex;
+            if (storagePlace.TextureIDs.find(currentIdx) != storagePlace.TextureIDs.end()) {
+                TexLoader.DeleteTexture(storagePlace.TextureIDs[currentIdx]);
+            }
+
             u32 layers = 1;
             auto array = TexLoader.GenerateTexture(width, height, layers);
-            storagePlace.TextureIDs[storagePlace.CurrentIndex] = array;
+            storagePlace.TextureIDs[currentIdx] = array;
             storagePlace.Countdown = texturePtr == nullptr ? 0 : (texturePtr->getLastScene().time + 1);
-            storagePlace.TimePerIndex[storagePlace.CurrentIndex] = storagePlace.Countdown;
-            storagePlace.LayerByIndex[storagePlace.CurrentIndex] = newStoragePlace.LayerByIndex[0];
+            storagePlace.TimePerIndex[currentIdx] = storagePlace.Countdown;
+            storagePlace.LayerByIndex[currentIdx] = newStoragePlace.LayerByIndex[0];
             storagePlace.WasReplacementEnabled = textureReplacementEnabled;
             
             entry.Texture = storagePlace;
 
-            TexLoader.UploadTexture(storagePlace.TextureIDs[storagePlace.CurrentIndex], width, height,
-                    storagePlace.LayerByIndex[storagePlace.CurrentIndex], imageData);
+            TexLoader.UploadTexture(storagePlace.TextureIDs[currentIdx], width, height,
+                    storagePlace.LayerByIndex[currentIdx], imageData);
 
-            textureHandle = storagePlace.TextureIDs[storagePlace.CurrentIndex];
-            layer = storagePlace.LayerByIndex[storagePlace.CurrentIndex];
+            if (imageData != (unsigned char*)DecodingBuffer) {
+                free(imageData);
+            }
+
+            textureHandle = storagePlace.TextureIDs[currentIdx];
+            layer = storagePlace.LayerByIndex[currentIdx];
             helper = &Cache.emplace(std::make_pair(key, entry)).first->second.LastVariant;
         }
         else {
@@ -424,7 +433,9 @@ public:
 
             TexLoader.UploadTexture(storagePlace.TextureIDs[storagePlace.CurrentIndex], width, height,
                     storagePlace.LayerByIndex[storagePlace.CurrentIndex], imageData);
-            //printf("using storage place %d %d | %d %d (%d)\n", width, height, storagePlace.TexArrayIdx, storagePlace.LayerIdx, array.ImageDescriptor);
+
+            if (imageData != (unsigned char*)DecodingBuffer)
+                free(imageData);
 
             textureHandle = storagePlace.TextureIDs[storagePlace.CurrentIndex];
             layer = storagePlace.LayerByIndex[storagePlace.CurrentIndex];


### PR DESCRIPTION
Fixes #442

## Issue

#442 documents memory leaks that caused RAM usage to grow to  ~18% of 64 GB. Title screen was noted to be where leak occurred and it was believed leaks may be originating someplace in video handling.

Upon investigation of how videos' memory are handled, I noticed that replacing and loading HD textures was not properly handling memory deallocation.

Specifically, original implementation had memory leaks when loading textures and converting them from RGB to RGBA format. The original image buffer was never freed after conversion and the converted image data was never freed after being uploaded to the GPU.

Additionally, when replacing textures, old GPU texture handles weren't being deleted before creating new ones.

## Solution

Add proper cleanup. Freeing the original `stbi_load` buffer after RGB-to-RGBA conversion, freeing the `imageData` after GPU upload (when it's not the shared decoding buffer), and deleting existing GPU textures before allocating replacements.

## Tested

This is running PR's local changes on a macOS `15.7.1` with `8 GB RAM 2133 MHz LPDDR3` and on a `Intel Iris Plus Graphics 645 1536 MB` graphics card.

https://github.com/user-attachments/assets/0db0d462-80ec-4132-91f6-083f1867fe24

First ~10 minutes of KH Days gameplay with my changes to KH MelonMix running a ROM. This includes several HD cutscenes, original DS in-game cutscenes, and some gameplay (walking, talking to NPCs, tutorial screen navigation).

> [!NOTE]
> Excuse choppiness of above video, the game actually runs well on somewhat older Mac computers. The video's choppiness is due to compressing the original 2GB `.mov` screen recorded file to a <10MB `.mp4` video running at 15 FPS, using free online compression tools and `ffmpeg` CLI. I aimed to at least keep text readable while showing roughly this working locally, for your convenience.

 ## Result
 
- Memory is stable and hovers between `520 - 545MB` usage without any signs of memory leakage (RAM usage increasing stepwise in Activity Monitor).
- After ~30 minutes of being idle, RAM usage remained at `545MB`.
- After ~60  minutes of being idle, RAM usage dropped to `512MB`.

> [!IMPORTANT]
> There may be memory leaks elsewhere not yet detected. But for the original suspected issue and where real leaks were happening, this PR remedies those issues.
