### PR TITLE
Add translations for HD cutscene pause menu

### DIFF
--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -98,7 +98,7 @@ void EmuThread::attachWindow(MainWindow* window)
         connect(this, SIGNAL(windowUpdateBgmMusicVolume(quint8)), window, SLOT(asyncUpdateBgmMusicVolume(quint8)));
         connect(this, SIGNAL(windowStopAllBgm()), window, SLOT(asyncStopAllBgm()));
 
-        connect(this, SIGNAL(windowStartVideo(QString,QString)), window, SLOT(asyncStartVideo(QString,QString)));
+        connect(this, SIGNAL(windowStartVideo(QString,QString,int)), window, SLOT(asyncStartVideo(QString,QString,int)));
         connect(this, SIGNAL(windowStopVideo()), window, SLOT(asyncStopVideo()));
         connect(this, SIGNAL(windowPauseVideo()), window, SLOT(asyncPauseVideo()));
         connect(this, SIGNAL(windowUnpauseVideo()), window, SLOT(asyncUnpauseVideo()));
@@ -136,7 +136,7 @@ void EmuThread::detachWindow(MainWindow* window)
         disconnect(this, SIGNAL(windowUpdateBgmMusicVolume(quint8)), window, SLOT(asyncUpdateBgmMusicVolume(quint8)));
         disconnect(this, SIGNAL(windowStopAllBgm()), window, SLOT(asyncStopAllBgm()));
 
-        disconnect(this, SIGNAL(windowStartVideo(QString,QString)), window, SLOT(asyncStartVideo(QString,QString)));
+        disconnect(this, SIGNAL(windowStartVideo(QString,QString,int)), window, SLOT(asyncStartVideo(QString,QString,int)));
         disconnect(this, SIGNAL(windowStopVideo()), window, SLOT(asyncStopVideo()));
         disconnect(this, SIGNAL(windowPauseVideo()), window, SLOT(asyncPauseVideo()));
         disconnect(this, SIGNAL(windowUnpauseVideo()), window, SLOT(asyncUnpauseVideo()));
@@ -941,7 +941,7 @@ void EmuThread::refreshPluginState()
                 QString filePath = QString::fromUtf8(path.c_str());
                 std::string subtitlesPath = emuInstance->plugin->replacementCutsceneSubtitlesFilePath(cutscene);
                 QString subtitlesFilePath = QString::fromUtf8(subtitlesPath.c_str());
-                emit windowStartVideo(filePath, subtitlesFilePath);
+                emit windowStartVideo(filePath, subtitlesFilePath, emuInstance->plugin->cutsceneMenuLanguage());
             }
         }
     }

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -173,7 +173,7 @@ signals:
     void windowUpdateBgmMusicVolume(quint8 volume);
     void windowStopAllBgm();
 
-    void windowStartVideo(QString videoFilePath, QString subtitlesFilePath);
+    void windowStartVideo(QString videoFilePath, QString subtitlesFilePath, int menuLanguage);
     void windowStopVideo();
     void windowPauseVideo();
     void windowUnpauseVideo();

--- a/src/frontend/qt_sdl/MainWindow/CutsceneVideoView.cpp
+++ b/src/frontend/qt_sdl/MainWindow/CutsceneVideoView.cpp
@@ -82,11 +82,39 @@ static void paintSubtitle(QPainter& p, int w, int h, const QString& text)
     }
 }
 
+// Localized pause-menu strings, indexed by DS firmware Language order
+// (0=ja, 1=en, 2=fr, 3=de, 4=it, 5=es). "Continue" wording matches the KH HD Collection's own
+// movie/pause menu; "Skip" has no collection equivalent (its theater uses "Return to Title
+// Screen"), so it uses standard translations - Italian "Salta" and Spanish "Saltar" do match
+// the collection's in-game skip wording. The title is the stylized "PAUSE" header: uppercased
+// to match the English logo (none of these words carry accents, so all-caps is safe) and using
+// the title *noun* per language (Pause/Pausa) rather than the collection's verb action label
+// ("Pausieren"/"Metti in pausa"). Japanese katakana ポーズ has no case. Stored as UTF-8 narrow
+// literals (this file is UTF-8, like subtitleLanguageFolder's folder names) and decoded via
+// QString::fromUtf8 at use.
+struct CutsceneMenuStrings { const char* title; const char* cont; const char* skip; };
+static CutsceneMenuStrings cutsceneMenuStrings(int language)
+{
+    static const CutsceneMenuStrings table[6] = {
+        { "ポーズ",  "つづける",     "スキップ" },        // 0 Japanese
+        { "PAUSE",  "Continue",    "Skip" },            // 1 English
+        { "PAUSE",  "Continuer",   "Passer" },          // 2 French
+        { "PAUSE",  "Fortfahren",  "Überspringen" },    // 3 German
+        { "PAUSA",  "Continua",    "Salta" },           // 4 Italian
+        { "PAUSA",  "Continuar",   "Saltar" },          // 5 Spanish
+    };
+    if (language < 0 || language >= 6) language = 1; // English fallback
+    return table[language];
+}
+
 // Paints the Skip/Continue menu in device (pixel) coordinates over a w*h area.
 // 't' is the animation clock in seconds, used to drive the hand bob and the glow
-// orbit so the selected entry matches the live KH2 pause menu.
-static void paintCutsceneSkipMenu(QPainter& p, int w, int h, int selection, double t)
+// orbit so the selected entry matches the live KH2 pause menu. 'language' selects the
+// localized labels (firmware Language order; see cutsceneMenuStrings).
+static void paintCutsceneSkipMenu(QPainter& p, int w, int h, int selection, double t, int language)
 {
+    const CutsceneMenuStrings strings = cutsceneMenuStrings(language);
+
     ensureCutsceneMenuAssets();
     static const QPixmap handPixmap(":/ds/menu_hand.png");
     static const QPixmap lightPixmap(":/ds/menu_light.png");
@@ -107,7 +135,7 @@ static void paintCutsceneSkipMenu(QPainter& p, int w, int h, int selection, doub
     titleFont.setItalic(true);
     p.setFont(titleFont);
 
-    const QString title = "PAUSE";
+    const QString title = QString::fromUtf8(strings.title);
     QFontMetrics tfm(titleFont);
     int titleW = tfm.horizontalAdvance(title);
     int titleH = tfm.height();
@@ -132,7 +160,7 @@ static void paintCutsceneSkipMenu(QPainter& p, int w, int h, int selection, doub
     p.drawLine(cx - lineHalf, lineYBot, cx + lineHalf, lineYBot);
 
     // Continue / Skip buttons in the rounded KH menu-entry font
-    const char* labels[2] = { "Continue", "Skip" };
+    const QString labels[2] = { QString::fromUtf8(strings.cont), QString::fromUtf8(strings.skip) };
     int btnW = (int)(w * 0.26);
     int btnH = (int)qMax(28.0, h * 0.075);
     int spacing = (int)(btnH * 0.35);
@@ -140,6 +168,18 @@ static void paintCutsceneSkipMenu(QPainter& p, int w, int h, int selection, doub
 
     QFont btnFont("KHMenu");
     btnFont.setPixelSize((int)qMax(15.0, h * 0.040));
+    // Some localized labels are wider than the English ones (e.g. German "Überspringen").
+    // Shrink the font until the widest label fits the button's flat area - the rounded caps
+    // eat ~btnH of width - so labels stay inside the button rather than being clipped.
+    {
+        const qreal avail = btnW - btnH;
+        QFontMetrics bfm(btnFont);
+        int widest = 0;
+        for (const QString& l : labels) widest = qMax(widest, bfm.horizontalAdvance(l));
+        if (widest > avail && avail > 0) {
+            btnFont.setPixelSize(qMax(10, (int)(btnFont.pixelSize() * avail / widest)));
+        }
+    }
     p.setFont(btnFont);
 
     for (int i = 0; i < 2; i++)
@@ -271,6 +311,14 @@ void CutsceneVideoView::setMenuSelection(int selection)
     }
 }
 
+void CutsceneVideoView::setMenuLanguage(int language)
+{
+    m_menuLanguage = language;
+    if (m_menuVisible && viewport()) {
+        viewport()->update();
+    }
+}
+
 void CutsceneVideoView::resizeEvent(QResizeEvent* event)
 {
     QGraphicsView::resizeEvent(event);
@@ -318,7 +366,7 @@ void CutsceneVideoView::drawForeground(QPainter* painter, const QRectF& rect)
     const double t = m_animClock.isValid() ? m_animClock.elapsed() / 1000.0 : 0.0;
     painter->save();
     painter->resetTransform();
-    paintCutsceneSkipMenu(*painter, viewport()->width(), viewport()->height(), m_menuSelection, t);
+    paintCutsceneSkipMenu(*painter, viewport()->width(), viewport()->height(), m_menuSelection, t, m_menuLanguage);
     painter->restore();
 }
 

--- a/src/frontend/qt_sdl/MainWindow/CutsceneVideoView.h
+++ b/src/frontend/qt_sdl/MainWindow/CutsceneVideoView.h
@@ -43,6 +43,9 @@ public:
     QGraphicsVideoItem* videoItem() const { return m_videoItem; }
     void setMenuVisible(bool visible);
     void setMenuSelection(int selection);
+    // Language for the pause-menu labels, in DS firmware Language order (0=ja, 1=en, 2=fr,
+    // 3=de, 4=it, 5=es). Out-of-range values fall back to English.
+    void setMenuLanguage(int language);
 
     // Parses a SubRip (.srt) subtitle file (empty path clears subtitles). See loadSubtitles.
     void loadSubtitles(const QString& filePath);
@@ -60,6 +63,7 @@ private:
     QGraphicsVideoItem* m_videoItem = nullptr;
     bool m_menuVisible = false;
     int m_menuSelection = 0; // 0 = Continue, 1 = Skip
+    int m_menuLanguage = 1;  // firmware Language order (0=ja, 1=en, 2=fr, 3=de, 4=it, 5=es)
 
     // Subtitle cues for the current cutscene, sorted by start time, and the active one (-1 = none).
     QVector<SubtitleCue> m_cues;

--- a/src/frontend/qt_sdl/MainWindow/MainWindowSettings.cpp
+++ b/src/frontend/qt_sdl/MainWindow/MainWindowSettings.cpp
@@ -365,13 +365,13 @@ void MainWindowSettings::createMenuSounds()
     }
 }
 
-void MainWindowSettings::asyncStartVideo(QString videoFilePath, QString subtitlesFilePath)
+void MainWindowSettings::asyncStartVideo(QString videoFilePath, QString subtitlesFilePath, int menuLanguage)
 {
     QMetaObject::invokeMethod(this, "startVideo", Qt::QueuedConnection,
-        Q_ARG(QString, videoFilePath), Q_ARG(QString, subtitlesFilePath));
+        Q_ARG(QString, videoFilePath), Q_ARG(QString, subtitlesFilePath), Q_ARG(int, menuLanguage));
 }
 
-void MainWindowSettings::startVideo(QString videoFilePath, QString subtitlesFilePath)
+void MainWindowSettings::startVideo(QString videoFilePath, QString subtitlesFilePath, int menuLanguage)
 {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     player->setMedia(QUrl::fromLocalFile(videoFilePath));
@@ -381,6 +381,8 @@ void MainWindowSettings::startVideo(QString videoFilePath, QString subtitlesFile
 
     // Load subtitles for this cutscene (an empty path clears any previous cues).
     playerView->loadSubtitles(subtitlesFilePath);
+    // Localize the pause menu to match the cutscene's language.
+    playerView->setMenuLanguage(menuLanguage);
 
     QStackedWidget* centralWidget = (QStackedWidget*)this->centralWidget();
     centralWidget->setCurrentWidget(playerView);

--- a/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
+++ b/src/frontend/qt_sdl/MainWindow/MainWindowSettings.h
@@ -65,12 +65,12 @@ public slots:
 
     void updateBgmMusicVolume(quint8 ramVolume);
 
-    void asyncStartVideo(QString videoFilePath, QString subtitlesFilePath);
+    void asyncStartVideo(QString videoFilePath, QString subtitlesFilePath, int menuLanguage);
     void asyncStopVideo();
     void asyncPauseVideo();
     void asyncUnpauseVideo();
 
-    void startVideo(QString videoFilePath, QString subtitlesFilePath);
+    void startVideo(QString videoFilePath, QString subtitlesFilePath, int menuLanguage);
     void stopVideo();
     void pauseVideo();
     void unpauseVideo();

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -218,6 +218,9 @@ public:
 
     virtual std::string replacementCutsceneFilePath(CutsceneEntry* cutscene) {return "";}
     virtual std::string replacementCutsceneSubtitlesFilePath(CutsceneEntry* cutscene) {return "";}
+    // Language for the HD cutscene pause menu, in DS firmware Language order
+    // (0=ja, 1=en, 2=fr, 3=de, 4=it, 5=es). Defaults to English.
+    virtual int cutsceneMenuLanguage() { return 1; }
 
     bool ShouldTerminateIngameCutscene();
     bool StoppedIngameCutscene();

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -2720,25 +2720,34 @@ std::string PluginKingdomHeartsDays::replacementCutsceneFilePath(CutsceneEntry* 
     return "";
 }
 
-// The subtitle language folder follows the cart region: USA is always English and JP always
+// The active language for cutscenes follows the cart region: USA is always English and JP always
 // Japanese, while the EU cart picks its language from the DS system (firmware) settings - the
-// same value the EU game itself reads to choose its in-game language.
-std::string PluginKingdomHeartsDays::subtitleLanguageFolder() {
+// same value the EU game itself reads to choose its in-game language. Returned in DS firmware
+// Language order (0=ja, 1=en, 2=fr, 3=de, 4=it, 5=es); shared by the subtitle folder and the
+// pause-menu localization.
+int PluginKingdomHeartsDays::cutsceneMenuLanguage() {
     if (isUsaCart()) {
-        return "English";
+        return 1; // English
     }
     if (isJapanCart()) {
-        return "日本語";
+        return 0; // Japanese
     }
-    // EU cart: map the firmware language (see Firmware::Language) to the subtitle folder.
+    // EU cart: map the firmware language (see Firmware::Language) to a 0-5 index.
     int language = nds->SPI.GetFirmware().GetEffectiveUserData().Settings & 0x7;
-    switch (language) {
+    if (language < 0 || language > 5) {
+        return 1; // English for anything unexpected
+    }
+    return language;
+}
+
+std::string PluginKingdomHeartsDays::subtitleLanguageFolder() {
+    switch (cutsceneMenuLanguage()) {
         case 0:  return "日本語";   // Japanese
         case 2:  return "Français"; // French
         case 3:  return "Deutsch";  // German
         case 4:  return "Italiano"; // Italian
         case 5:  return "Español";  // Spanish
-        default: return "English";  // English (1) and anything unexpected
+        default: return "English";  // English (1)
     }
 }
 

--- a/src/plugins/PluginKingdomHeartsDays.h
+++ b/src/plugins/PluginKingdomHeartsDays.h
@@ -61,6 +61,7 @@ public:
 
     std::string replacementCutsceneFilePath(CutsceneEntry* cutscene) override;
     std::string replacementCutsceneSubtitlesFilePath(CutsceneEntry* cutscene) override;
+    int cutsceneMenuLanguage() override;
     std::string subtitleLanguageFolder();
     std::string localizationFilePath(std::string language) override;
     std::filesystem::path patchReplacementCutsceneIfNeeded(CutsceneEntry* cutscene, std::filesystem::path folderPath);

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -2742,6 +2742,24 @@ CutsceneEntry* PluginKingdomHeartsReCoded::getMobiCutsceneByAddress(u32 cutscene
     return cutscene1;
 }
 
+// Language for the HD cutscene pause menu, following the cart region (USA->English,
+// JP->Japanese, EU->firmware language). Returned in DS firmware Language order
+// (0=ja, 1=en, 2=fr, 3=de, 4=it, 5=es).
+int PluginKingdomHeartsReCoded::cutsceneMenuLanguage()
+{
+    if (isUsaCart()) {
+        return 1; // English
+    }
+    if (isJapanCart()) {
+        return 0; // Japanese
+    }
+    int language = nds->SPI.GetFirmware().GetEffectiveUserData().Settings & 0x7;
+    if (language < 0 || language > 5) {
+        return 1; // English for anything unexpected
+    }
+    return language;
+}
+
 u8 PluginKingdomHeartsReCoded::getU8ByCart(u8 usAddress, u8 euAddress, u8 jpAddress)
 {
     u8 cutsceneAddress = 0;

--- a/src/plugins/PluginKingdomHeartsReCoded.h
+++ b/src/plugins/PluginKingdomHeartsReCoded.h
@@ -23,6 +23,8 @@ public:
     bool isEuropeCart() { return GameCode == euGamecode; };
     bool isJapanCart()  { return GameCode == jpGamecode; };
 
+    int cutsceneMenuLanguage() override;
+
     void loadLocalization();
     std::string saveFilePath();
     bool shouldStartInFullscreen() override;


### PR DESCRIPTION
Added translations of the HD cutscene Pause menu in all languages supported natively by the game

<img width="1918" height="1138" alt="Screenshot from 2026-06-16 16-55-56" src="https://github.com/user-attachments/assets/de74f280-7e08-445c-b407-4b3889b514c5" />
