### PR TITLE
Fix input config bugs and add ZL/ZR support for NSO SNES controller

### DIFF
--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -1916,6 +1916,8 @@ bool EmuInstance::loadROM(QStringList filepath, bool reset, QString& errorstr)
             Config::Table& ref = const_cast <Config::Table&>(cfg);
             ref.SetString(path, value);
         });
+
+        Config::Save();
     }
 
     ndsSave = nullptr;

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -163,7 +163,10 @@ public:
     int getJoystickUniqueIdById(int id);
     int getJoystickIdByUniqueId(int uniqueId);
     SDL_Joystick* getJoystick() { return joystick; }
+    SDL_GameController* getController() { return controller; }
     std::shared_ptr<SDL_mutex> getJoyMutex() { return joyMutex; }
+    const melonDS::u8* getHidReport() const { return hidReport; }
+    void pollHidReport();
 
     std::vector<int> heldKeys;
     std::vector<int> keyStrokes;
@@ -381,6 +384,8 @@ private:
     int joystickUniqueID;
     SDL_Joystick* joystick;
     SDL_GameController* controller;
+    SDL_hid_device* hidDevice = nullptr;
+    melonDS::u8 hidReport[64];
     bool hasAccelerometer = false;
     bool hasGyroscope = false;
     bool hasRumble = false;

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -114,6 +114,8 @@ void EmuInstance::inputInit()
 
     joystick = nullptr;
     controller = nullptr;
+    hidDevice = nullptr;
+    memset(hidReport, 0, sizeof(hidReport));
     hasRumble = false;
     hasAccelerometer = false;
     hasGyroscope = false;
@@ -132,10 +134,11 @@ void EmuInstance::inputDeInit()
 void EmuInstance::inputLoadConfig()
 {
     SDL_LockMutex(joyMutex.get());
-    setJoystickByUniqueId(localCfg.GetInt("JoystickUniqueID"));
+    int savedUniqueId = localCfg.GetInt("JoystickUniqueID");
+    setJoystickByUniqueId(savedUniqueId);
 
     Config::Table keycfg = localCfg.GetTable("Keyboard");
-    Config::Table joycfg = localCfg.GetTable("Joystick." + std::to_string(joystickUniqueID));
+    Config::Table joycfg = localCfg.GetTable("Joystick." + std::to_string(savedUniqueId));
 
     for (int i = 0; i < 12; i++)
     {
@@ -252,7 +255,7 @@ void EmuInstance::setJoystick(int id)
     SDL_LockMutex(joyMutex.get());
     joystickID = id;
     joystickUniqueID = uniqueId;
-    openJoystick();
+    closeJoystick();  // let EmuThread re-open on next inputProcess() — avoids blocking main thread
     SDL_UnlockMutex(joyMutex.get());
 }
 
@@ -268,7 +271,7 @@ void EmuInstance::setJoystickByUniqueId(int uniqueId)
     SDL_LockMutex(joyMutex.get());
     joystickID = id;
     joystickUniqueID = uniqueId;
-    openJoystick();
+    closeJoystick();  // let EmuThread re-open on next inputProcess() — avoids blocking main thread
     SDL_UnlockMutex(joyMutex.get());
 }
 
@@ -320,9 +323,7 @@ void EmuInstance::openJoystick()
     joystick = SDL_JoystickOpen(joystickID);
 
     if (SDL_IsGameController(joystickID))
-    {
         controller = SDL_GameControllerOpen(joystickID);
-    }
 
     if (controller)
     {
@@ -338,6 +339,33 @@ void EmuInstance::openJoystick()
         {
             hasGyroscope = SDL_GameControllerSetSensorEnabled(controller, SDL_SENSOR_GYRO, SDL_TRUE) == 0;
         }
+
+        // If the GC descriptor has no trigger mapping (CoreHID/Apple VID after device switch),
+        // open a raw HID channel to the Nintendo device for ZL/ZR detection.
+        SDL_GameControllerButtonBind trigBind =
+            SDL_GameControllerGetBindForAxis(controller, SDL_CONTROLLER_AXIS_TRIGGERLEFT);
+        if (trigBind.bindType == SDL_CONTROLLER_BINDTYPE_NONE)
+        {
+            if (hidDevice) { SDL_hid_close(hidDevice); hidDevice = nullptr; }
+            hidDevice = SDL_hid_open(0x057E, 0x2017, NULL);
+            if (hidDevice)
+            {
+                // Drain the initial wakeup report (byte-identical to ZL pressed).
+                // Without this drain hidReport[1] would stay 0x40 → persistent false ZL.
+                u8 drain[64];
+                SDL_hid_read_timeout(hidDevice, drain, sizeof(drain), 50);
+                if (SDL_hid_set_nonblocking(hidDevice, 1) != 0)
+                {
+                    SDL_hid_close(hidDevice);
+                    hidDevice = nullptr;
+                }
+                else
+                {
+                    while (SDL_hid_read(hidDevice, drain, sizeof(drain)) > 0) {}
+                }
+            }
+            memset(hidReport, 0, sizeof(hidReport));
+        }
     }
 }
 
@@ -350,12 +378,19 @@ void EmuInstance::closeJoystick()
         hasRumble = false;
         hasAccelerometer = false;
         hasGyroscope = false;
+        isRumbling = false;
     }
     if (joystick)
     {
         SDL_JoystickClose(joystick);
         joystick = nullptr;
     }
+    if (hidDevice)
+    {
+        SDL_hid_close(hidDevice);
+        hidDevice = nullptr;
+    }
+    memset(hidReport, 0, sizeof(hidReport));
 }
 
 
@@ -513,12 +548,39 @@ Sint16 EmuInstance::joystickButtonDown(int val)
             break;
 
         case 2: // trigger
-            if (axisval > 0) return 1;
+        {
+            Sint16 trigval;
+            if (controller && (axisnum == SDL_CONTROLLER_AXIS_TRIGGERLEFT
+                            || axisnum == SDL_CONTROLLER_AXIS_TRIGGERRIGHT))
+                trigval = SDL_GameControllerGetAxis(controller, (SDL_GameControllerAxis)axisnum);
+            else
+                trigval = axisval;
+            if (trigval == 0 && hidReport[0] == 0x3F)
+            {
+                bool pressed = (axisnum == SDL_CONTROLLER_AXIS_TRIGGERLEFT)
+                    ? (hidReport[1] & 0x40) != 0
+                    : (hidReport[2] & 0x80) != 0;
+                if (pressed) trigval = 32767;
+            }
+            if (trigval > 16384) return 1;
             break;
+        }
         }
     }
 
     return 0;
+}
+
+void EmuInstance::pollHidReport()
+{
+    if (!hidDevice) return;
+    u8 buf[64];
+    int n;
+    while ((n = SDL_hid_read(hidDevice, buf, sizeof(buf))) != 0)
+    {
+        if (n < 0) { SDL_hid_close(hidDevice); hidDevice = nullptr; memset(hidReport, 0, sizeof(hidReport)); break; }
+        if (n >= 3 && buf[0] == 0x3F) memcpy(hidReport, buf, n);
+    }
 }
 
 void EmuInstance::inputProcess()
@@ -538,6 +600,8 @@ void EmuInstance::inputProcess()
     {
         openJoystick();
     }
+
+    pollHidReport();
 
     joyInputMask = 0xFFF;
     joyTouchInputMask = 0xFFFF;

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.cpp
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.cpp
@@ -104,6 +104,7 @@ InputConfigDialog::InputConfigDialog(QWidget* parent) : QDialog(parent), ui(new 
 
     populatePage(ui->tabHotkeysGeneral, std::vector<const char*>(hk_general_labels), hkGeneralKeyMap, hkGeneralJoyMap);
 
+    ui->cbxJoystick->blockSignals(true);
     if (njoy > 0)
     {
         for (int i = 0; i < njoy; i++)
@@ -118,10 +119,14 @@ InputConfigDialog::InputConfigDialog(QWidget* parent) : QDialog(parent), ui(new 
         ui->cbxJoystick->addItem("(no joysticks available)");
         ui->cbxJoystick->setEnabled(false);
     }
+    ui->cbxJoystick->blockSignals(false);
 
     setupKeypadPage();
     setupAddonsPage();
     setupTouchScreenPage();
+
+    joystickBindingModified = false;
+    originalJoystickDefaultsApplied = false;
 
     auto plugin = emuInstance->plugin;
     if (plugin != nullptr)
@@ -129,7 +134,10 @@ InputConfigDialog::InputConfigDialog(QWidget* parent) : QDialog(parent), ui(new 
         std::string root = plugin->tomlUniqueIdentifier();
         auto& globalCfg = emuInstance->getGlobalConfig();
         enableAutomaticJoystickMappingForGame = !globalCfg.GetBool(root + ".DisableAutomaticJoystickMapping");
+        originalJoystickDefaultsApplied = globalCfg.GetBool(root + ".JoystickDefaultsApplied");
+        ui->cbAutoMapJoysticksForGame->blockSignals(true);
         ui->cbAutoMapJoysticksForGame->setChecked(enableAutomaticJoystickMappingForGame);
+        ui->cbAutoMapJoysticksForGame->blockSignals(false);
     }
 
     int inst = emuInstance->getInstanceID();
@@ -305,6 +313,15 @@ void InputConfigDialog::on_InputConfigDialog_accepted()
         joycfg.SetInt(btn, touchScreenJoyMap[i]);
     }
 
+    if (joystickBindingModified && plugin != nullptr
+            && ui->cbAutoMapJoysticksForGame->isChecked())
+    {
+        std::string root = plugin->tomlUniqueIdentifier();
+        auto& globalCfg = emuInstance->getGlobalConfig();
+        globalCfg.SetBool(root + ".DisableAutomaticJoystickMapping", true);
+        globalCfg.SetBool(root + ".JoystickDefaultsApplied", false);
+    }
+
     instcfg.SetInt("JoystickUniqueID", joystickUniqueID);
     Config::Save();
 
@@ -321,6 +338,7 @@ void InputConfigDialog::on_InputConfigDialog_rejected()
         std::string root = plugin->tomlUniqueIdentifier();
         auto& glocalCfg = emuInstance->getGlobalConfig();
         glocalCfg.SetBool(root + ".DisableAutomaticJoystickMapping", !enableAutomaticJoystickMappingForGame);
+        glocalCfg.SetBool(root + ".JoystickDefaultsApplied", originalJoystickDefaultsApplied);
     }
 
     Config::Table& instcfg = emuInstance->getLocalConfig();
@@ -341,7 +359,6 @@ void InputConfigDialog::on_btnJoyMapSwitch_clicked()
 
 void InputConfigDialog::on_cbxJoystick_currentIndexChanged(int id)
 {
-    // prevent a spurious change
     if (ui->cbxJoystick->count() < 2) return;
 
     Config::Table& instcfg = emuInstance->getLocalConfig();
@@ -412,13 +429,13 @@ void InputConfigDialog::on_cbxJoystick_currentIndexChanged(int id)
     if (plugin != nullptr) {
         for (i = 0; i < plugin->customKeyMappingNames.size(); i++)
         {
-            joycfg.SetInt(plugin->customKeyMappingNames[i], pluginJoyMap[i]);
+            pluginJoyMap[i] = joycfg.GetInt(plugin->customKeyMappingNames[i]);
         }
     }
 
     for (i = 0; i < touchscreen_num; i++)
     {
-        joycfg.SetInt(EmuInstance::touchButtonNames[dstouchkeyorder[i]], touchScreenJoyMap[i]);
+        touchScreenJoyMap[i] = joycfg.GetInt(EmuInstance::touchButtonNames[dstouchkeyorder[i]]);
     }
 
     emuInstance->inputLoadConfig();
@@ -441,6 +458,8 @@ void InputConfigDialog::on_cbAutoMapJoysticksForGame_stateChanged(int state)
         std::string root = plugin->tomlUniqueIdentifier();
         auto& globalCfg = emuInstance->getGlobalConfig();
         globalCfg.SetBool(root + ".DisableAutomaticJoystickMapping", state == 0);
+        if (state != 0)
+            globalCfg.SetBool(root + ".JoystickDefaultsApplied", false);
     }
 }
 
@@ -449,7 +468,23 @@ SDL_Joystick* InputConfigDialog::getJoystick()
     return emuInstance->getJoystick();
 }
 
+SDL_GameController* InputConfigDialog::getController()
+{
+    return emuInstance->getController();
+}
+
 std::shared_ptr<SDL_mutex> InputConfigDialog::getJoyMutex()
 {
     return emuInstance->getJoyMutex();
+}
+
+const melonDS::u8* InputConfigDialog::pollAndGetHidReport()
+{
+    emuInstance->pollHidReport();
+    return emuInstance->getHidReport();
+}
+
+void InputConfigDialog::notifyJoystickBindingChanged()
+{
+    joystickBindingModified = true;
 }

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
@@ -115,7 +115,11 @@ public:
     ~InputConfigDialog();
 
     SDL_Joystick* getJoystick();
+    SDL_GameController* getController();
     std::shared_ptr<SDL_mutex> getJoyMutex();
+    const melonDS::u8* pollAndGetHidReport();
+
+    void notifyJoystickBindingChanged();
 
     static InputConfigDialog* currentDlg;
     static InputConfigDialog* openDlg(QWidget* parent)
@@ -165,6 +169,8 @@ private:
     int joystickID;
     int joystickUniqueID;
     int enableAutomaticJoystickMappingForGame;
+    bool originalJoystickDefaultsApplied;
+    bool joystickBindingModified;
 };
 
 

--- a/src/frontend/qt_sdl/InputConfig/MapButton.h
+++ b/src/frontend/qt_sdl/InputConfig/MapButton.h
@@ -174,6 +174,7 @@ public:
         connect(this, &JoyMapButton::clicked, this, &JoyMapButton::onClick);
 
         timerID = 0;
+        mappingAtStart = 0;
     }
 
     ~JoyMapButton()
@@ -285,6 +286,44 @@ protected:
                 return;
             }
         }
+
+        // Try SDL's GameController API first (works when triggers are in the GC mapping).
+        SDL_GameController* gc = parentDialog->getController();
+        if (gc)
+        {
+            const SDL_GameControllerAxis triggers[] = {
+                SDL_CONTROLLER_AXIS_TRIGGERLEFT,
+                SDL_CONTROLLER_AXIS_TRIGGERRIGHT
+            };
+            for (SDL_GameControllerAxis axis : triggers)
+            {
+                if (SDL_GameControllerGetAxis(gc, axis) > 16384)
+                {
+                    *mapping = (oldmap & 0xFFFF) | 0x10000 | (2 << 20) | ((int)axis << 24);
+                    click();
+                    return;
+                }
+            }
+        }
+
+        // Raw HID fallback for NSO SNES via CoreHID (GC descriptor has no trigger entries).
+        // ZL = report[1] bit 6 (0x40), ZR = report[2] bit 7 (0x80), confirmed empirically.
+        const melonDS::u8* hr = parentDialog->pollAndGetHidReport();
+        if (hr[0] == 0x3F)
+        {
+            if (hr[1] & 0x40)
+            {
+                *mapping = (oldmap & 0xFFFF) | 0x10000 | (2 << 20) | (SDL_CONTROLLER_AXIS_TRIGGERLEFT << 24);
+                click();
+                return;
+            }
+            if (hr[2] & 0x80)
+            {
+                *mapping = (oldmap & 0xFFFF) | 0x10000 | (2 << 20) | (SDL_CONTROLLER_AXIS_TRIGGERRIGHT << 24);
+                click();
+                return;
+            }
+        }
     }
 
     void timerEvent(QTimerEvent* event) override
@@ -302,6 +341,7 @@ private slots:
     {
         if (isChecked())
         {
+            mappingAtStart = *mapping;
             setText("[press button/axis]");
             timerID = startTimer(50);
 
@@ -325,6 +365,8 @@ private slots:
         {
             setText(mappingText());
             if (timerID) { killTimer(timerID); timerID = 0; }
+            if (*mapping != mappingAtStart && parentDialog)
+                parentDialog->notifyJoystickBindingChanged();
         }
     }
 
@@ -387,6 +429,7 @@ private:
     bool isHotkey;
 
     int timerID;
+    int mappingAtStart;
     int axesRest[16];
 };
 

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -308,6 +308,8 @@ int main(int argc, char** argv)
 
     // http://stackoverflow.com/questions/14543333/joystick-wont-work-using-sdl
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_NINTENDO_CLASSIC, "1");
 
     SDL_SetHint(SDL_HINT_APP_NAME, "melonDS");
 

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -1336,6 +1336,7 @@ void Plugin::_superLoadConfigs(
     EnhancedGraphics = !getBoolConfig(root + ".DisableEnhancedGraphics");
     SingleScreenMode = !getBoolConfig(root + ".DisableSingleScreenMode");
     AutomaticallyMapJoysticks = !getBoolConfig(root + ".DisableAutomaticJoystickMapping");
+    JoystickDefaultsApplied = getBoolConfig(root + ".JoystickDefaultsApplied");
     DisableReplacementTextures = false;
     FastForwardLoadingScreens = getBoolConfig(root + ".FastForwardLoadingScreens");
     DaysDisableHisMemories = getBoolConfig(root + ".DaysDisableHisMemories");

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -415,6 +415,7 @@ protected:
     bool EnhancedGraphics = true;
     bool SingleScreenMode = true;
     bool AutomaticallyMapJoysticks = false;
+    bool JoystickDefaultsApplied = false;
     bool DisableReplacementTextures = false;
     bool FastForwardLoadingScreens = false;
     bool DaysDisableHisMemories = false;

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -356,6 +356,7 @@ void PluginKingdomHeartsDays::overrideConfigs(
     if (AutomaticallyMapJoysticks)
     {
         overrideJoystickMappings(setIntConfig);
+        setBoolConfig(tomlUniqueIdentifier() + ".JoystickDefaultsApplied", true);
     }
 
     KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
@@ -403,7 +404,8 @@ void PluginKingdomHeartsDays::overrideJoystickMappings(std::function<void(std::s
     KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
     if (config == nullptr)
     {
-        KingdomHeartsHDCollection::applyJoystickMappings(setIntConfig, false);
+        if (!JoystickDefaultsApplied)
+            KingdomHeartsHDCollection::applyJoystickMappings(setIntConfig, false);
         return;
     }
 

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -358,6 +358,7 @@ void PluginKingdomHeartsReCoded::overrideConfigs(
     if (AutomaticallyMapJoysticks)
     {
         overrideJoystickMappings(setIntConfig);
+        setBoolConfig(tomlUniqueIdentifier() + ".JoystickDefaultsApplied", true);
     }
 
     KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
@@ -405,7 +406,8 @@ void PluginKingdomHeartsReCoded::overrideJoystickMappings(std::function<void(std
     KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
     if (config == nullptr)
     {
-        KingdomHeartsHDCollection::applyJoystickMappings(setIntConfig, false);
+        if (!JoystickDefaultsApplied)
+            KingdomHeartsHDCollection::applyJoystickMappings(setIntConfig, false);
         return;
     }
 


### PR DESCRIPTION
While adding ZL/ZR support for the Nintendo Switch Online SNES controller, a few latent input config bugs surfaced:

Opening the Input Config dialog while a game was running would permanently freeze the emulator. The joystick open code does a blocking read to clear a startup packet from the device, and that was happening on the main thread. Moved it to the emulator thread instead.

Switching joysticks in the Input Config dialog was writing garbage into the plugin and touch screen button mappings instead of loading the saved values for the new controller. Copy-paste error — the loading code was calling SetInt where it should have been calling GetInt.

The "Automatically map joysticks for this game" checkbox now works as a starting point rather than a permanent setting. If the user manually changes and saves any joystick binding while it's on, the checkbox turns itself off so their custom layout isn't wiped the next time the ROM loads. Re-enabling it always starts from scratch.

As for the NSO SNES itself: ZL and ZR didn't work on macOS because SDL sees the controller twice — once as Nintendo's device, once through Apple's input layer — and neither path reports them through the standard GameController API. The fix opens a raw HID connection directly to the Nintendo device and reads the buttons from the input report (report ID 0x3F, ZL at byte 1 bit 6, ZR at byte 2 bit 7).