### PR TITLE
Fix BGM replacement accumulating playback streams

### DIFF
--- a/src/frontend/qt_sdl/MainWindow/AudioPlayer.cpp
+++ b/src/frontend/qt_sdl/MainWindow/AudioPlayer.cpp
@@ -56,7 +56,7 @@ void AudioPlayer::createAudioSink(const QAudioDevice& audioOutput) {
 }
 
 void AudioPlayer::restartAudioSink(const QAudioDevice& audioOutput) {
-    if (m_playing && m_audioSource) {
+    if (m_audioOutput && m_audioOutput->state() != QAudio::StoppedState && m_audioSource) {
         m_audioOutput->stop();
         createAudioSink(audioOutput);
         m_audioOutput->start(m_audioSource.get());
@@ -84,10 +84,16 @@ void AudioPlayer::stop(int fadeOutMs)
     if (!m_audioOutput) {
         return;
     }
+    m_playing = false;
     if (fadeOutMs == 0) {
         onFadeOutCompleted();
     } else {
         m_audioSource->startFadeOut(fadeOutMs);
+        m_cleanupTimer.reset(new QTimer());
+        m_cleanupTimer->setSingleShot(true);
+        m_cleanupTimer->setInterval(fadeOutMs + 2000);
+        QObject::connect(m_cleanupTimer.get(), &QTimer::timeout, this, &AudioPlayer::onFadeOutCompleted);
+        m_cleanupTimer->start();
     }
 }
 
@@ -99,10 +105,16 @@ qint64 AudioPlayer::getCurrentPlayingPos() const
 
 void AudioPlayer::onFadeOutCompleted()
 {
+    if (m_cleanupTimer) {
+        m_cleanupTimer->stop();
+        m_cleanupTimer.reset();
+    }
+    if (m_fadeCompleted) return;
+    m_fadeCompleted = true;
+
     if (m_audioOutput) {
         m_audioOutput->stop();
         m_audioSource->onStopped();
-        m_playing = false;
     }
 
     QMetaObject::invokeMethod(parent(), "onBgmFadeOutCompleted", Qt::QueuedConnection, Q_ARG(melonMix::AudioPlayer*, this));

--- a/src/frontend/qt_sdl/MainWindow/AudioPlayer.h
+++ b/src/frontend/qt_sdl/MainWindow/AudioPlayer.h
@@ -3,6 +3,8 @@
 
 #include <QObject>
 #include <QAudioSink>
+#include <QScopedPointer>
+#include <QTimer>
 
 namespace melonMix {
 
@@ -38,9 +40,11 @@ private:
 
     QScopedPointer<AudioSource> m_audioSource;
     QScopedPointer<QAudioSink> m_audioOutput;
+    QScopedPointer<QTimer> m_cleanupTimer;
 
     quint16 m_bgmId = 0;
     bool m_playing = false;
+    bool m_fadeCompleted = false;
 };
 
 } // namespace melonMix

--- a/src/frontend/qt_sdl/MainWindow/MainWindowSettings.cpp
+++ b/src/frontend/qt_sdl/MainWindow/MainWindowSettings.cpp
@@ -103,6 +103,12 @@ void MainWindowSettings::startBgmMusic(quint16 bgmId, quint8 volume, bool bResum
     if (bgmMusicFilePath.isEmpty())
         return;
 
+    for (auto* player : bgmPlayers) {
+        if (player->getBgmId() == bgmId && player->isPlaying()) {
+            return;
+        }
+    }
+
     melonMix::AudioPlayer* bgmPlayer = new melonMix::AudioPlayer(this, bgmId);
     bgmPlayer->loadFile(bgmMusicFilePath);
 
@@ -259,6 +265,7 @@ void MainWindowSettings::onBgmFadeOutCompleted(melonMix::AudioPlayer* playerStop
             it++;
         }
     }
+    printf("BGM players remaining after cleanup: %d\n", (int)bgmPlayers.size());
 }
 
 void MainWindowSettings::createVideoPlayer()


### PR DESCRIPTION
Fixes #481.

During long play sessions with BGM replacement, audio players were accumulating without being cleaned up. Each holds an OS-level audio stream, so the system would eventually degrade — slowdown, music stopping, cutscenes freezing.

The cleanup code relies on the audio thread signaling completion after a fade, but that signal was never arriving. The reason: whenever a new song started, it called `startFadeOut` on all accumulated players, which unconditionally reset their cleanup delays. More players meant more resets every transition, so cleanup kept getting deferred indefinitely.

The fix sets `m_playing = false` when `stop()` is called rather than waiting for the fade to end. Accumulated players get skipped on future stop calls, so their delays stop being reset and the cleanup chain can finally run. Added a safety timer as a fallback for when the audio-thread signal fails silently, with a double-fire guard. Also added a dedup guard in `startBgmMusic` as a secondary line of defense against accumulation from timing edge cases.

Also fixed `restartAudioSink` — the `m_playing` timing change would have broken seamless audio device switching mid-fade.

Tested on macOS with a 1-hour session: no accumulation, no slowdown, player count returns to 0 after each song cycle.