### PR TITLE
Apply the HD Collection launcher's window mode at game start

### DIFF
--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -131,6 +131,7 @@ DefaultList<bool> DefaultBools =
     {"3D.GL.HiresCoordinates", true},
     {"LimitFPS", true},
     {"Instance*.Window*.ShowOSD", true},
+    {"Instance*.Window*.FullscreenBorderless", true},
     {"Emu.DirectBoot", true},
     {"Mouse.Hide", true},
     {"Instance*.DS.Battery.LevelOkay", true},

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -249,11 +249,9 @@ void EmuThread::run()
                 // Apply the launcher's chosen display mode at game start
                 // (0 = fullscreen, 1 = borderless, 2 = windowed; -1 = leave as-is).
                 // The launcher's resolution sizes the window in windowed mode.
-                int displayMode = emuInstance->plugin->startupWindowMode();
-                if (displayMode >= 0) {
-                    emit windowSetDisplayMode(displayMode,
-                        emuInstance->plugin->startupWindowWidth(),
-                        emuInstance->plugin->startupWindowHeight());
+                Plugins::StartupWindowConfig windowConfig = emuInstance->plugin->startupWindowConfig();
+                if (windowConfig.mode >= 0) {
+                    emit windowSetDisplayMode(windowConfig.mode, windowConfig.width, windowConfig.height);
                 }
                 emuInstance->inputLoadConfig();
 

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -81,6 +81,7 @@ void EmuThread::attachWindow(MainWindow* window)
     connect(this, SIGNAL(windowEmuReset()), window, SLOT(onEmuReset()));
     connect(this, SIGNAL(autoScreenSizingChange(int)), window->panel, SLOT(onAutoScreenSizingChanged(int)));
     connect(this, SIGNAL(windowFullscreenToggle()), window, SLOT(onFullscreenToggled()));
+    connect(this, SIGNAL(windowSetDisplayMode(int,int,int)), window, SLOT(onSetDisplayMode(int,int,int)));
     connect(this, SIGNAL(screenEmphasisToggle()), window, SLOT(onScreenEmphasisToggled()));
 
     if (window->winHasMenu())
@@ -119,6 +120,7 @@ void EmuThread::detachWindow(MainWindow* window)
     disconnect(this, SIGNAL(windowEmuReset()), window, SLOT(onEmuReset()));
     disconnect(this, SIGNAL(autoScreenSizingChange(int)), window->panel, SLOT(onAutoScreenSizingChanged(int)));
     disconnect(this, SIGNAL(windowFullscreenToggle()), window, SLOT(onFullscreenToggled()));
+    disconnect(this, SIGNAL(windowSetDisplayMode(int,int,int)), window, SLOT(onSetDisplayMode(int,int,int)));
     disconnect(this, SIGNAL(screenEmphasisToggle()), window, SLOT(onScreenEmphasisToggled()));
 
     if (window->winHasMenu())
@@ -244,8 +246,14 @@ void EmuThread::run()
             }
             if (shouldStartPlugin)
             {
-                if (emuInstance->plugin->shouldStartInFullscreen()) {
-                    emit windowFullscreenToggle();
+                // Apply the launcher's chosen display mode at game start
+                // (0 = fullscreen, 1 = borderless, 2 = windowed; -1 = leave as-is).
+                // The launcher's resolution sizes the window in windowed mode.
+                int displayMode = emuInstance->plugin->startupWindowMode();
+                if (displayMode >= 0) {
+                    emit windowSetDisplayMode(displayMode,
+                        emuInstance->plugin->startupWindowWidth(),
+                        emuInstance->plugin->startupWindowHeight());
                 }
                 emuInstance->inputLoadConfig();
 

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -158,6 +158,7 @@ signals:
     void autoScreenSizingChange(int sizing);
 
     void windowFullscreenToggle();
+    void windowSetDisplayMode(int mode, int width, int height);
 
     void swapScreensToggle();
     void screenEmphasisToggle();

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -859,7 +859,12 @@ void MainWindow::closeEvent(QCloseEvent* event)
 
     if (!emuInstance) return;
 
-    QByteArray geom = saveGeometry();
+    // If we are closing while in borderless fullscreen, persist the underlying
+    // windowed geometry (saved when entering it) instead of the screen-covering
+    // frameless one, so the window reopens at its normal size.
+    QByteArray geom = (fullscreenActive && (windowFlags() & Qt::FramelessWindowHint) && !savedGeometry.isEmpty())
+        ? savedGeometry
+        : saveGeometry();
     QByteArray enc = geom.toBase64(QByteArray::Base64Encoding);
     windowCfg.SetString("Geometry", enc.toStdString());
     Config::Save();
@@ -2265,28 +2270,104 @@ void MainWindow::onTitleUpdate(QString title)
     setWindowTitle(title);
 }
 
-void MainWindow::toggleFullscreen()
+void MainWindow::setFullscreenMode(int mode, int width, int height)
 {
-    if (!isFullScreen())
+    // mode: 0 = fullscreen (exclusive), 1 = borderless windowed, 2 = windowed.
+    // Mirrors the HD Collection launcher's display-mode setting. width/height
+    // (when > 0) size the window in windowed mode, matching the launcher's
+    // configured resolution.
+    bool wasBorderless = (windowFlags() & Qt::FramelessWindowHint);
+
+    if (mode == 2)
     {
-        showFullScreen();
-        if (hasMenu)
-            menuBar()->setFixedHeight(0); // Don't use hide() as menubar actions stop working
-    }
-    else
-    {
+        // -> windowed. Drop the frameless flag first if we were borderless.
+        if (wasBorderless)
+            setWindowFlag(Qt::FramelessWindowHint, false);
         showNormal();
+
+        if (width > 0 && height > 0)
+        {
+            // Size the window to the launcher's resolution, centered on the
+            // screen it currently sits on.
+            QRect avail = screen()->availableGeometry();
+            int x = avail.x() + (avail.width()  - width)  / 2;
+            int y = avail.y() + (avail.height() - height) / 2;
+            setGeometry(x, y, width, height);
+        }
+        else if (wasBorderless && !savedGeometry.isEmpty())
+        {
+            restoreGeometry(savedGeometry);
+        }
+
         if (hasMenu)
         {
             int menuBarHeight = menuBar()->sizeHint().height();
             menuBar()->setFixedHeight(menuBarHeight);
         }
+        fullscreenActive = false;
+        return;
+    }
+
+    // mode 0 or 1: remember the windowed geometry the first time we go fullscreen.
+    if (!fullscreenActive)
+        savedGeometry = saveGeometry();
+
+    if (mode == 1)
+    {
+        // True borderless windowed: a frameless top-level window covering the
+        // screen it currently sits on. This never uses Qt's WindowFullScreen
+        // state, so there is no exclusive-mode switch.
+        //
+        // IMPORTANT: a frameless window whose rect EXACTLY matches the monitor
+        // gets promoted by Windows to "fullscreen optimization" (DirectFlip),
+        // which behaves like exclusive fullscreen and flickers on alt-tab. To
+        // keep it a real, DWM-composited borderless window (no flicker, instant
+        // alt-tab), we make it 1px taller than the screen so its rect is not an
+        // exact monitor match. That extra row sits just off the bottom edge and
+        // is never visible.
+        QRect screenGeo = screen()->geometry();
+        setWindowState(windowState() & ~(Qt::WindowFullScreen | Qt::WindowMaximized));
+        setWindowFlag(Qt::FramelessWindowHint, true);
+        setGeometry(screenGeo.x(), screenGeo.y(), screenGeo.width(), screenGeo.height() + 1);
+        show();
+        raise();
+        activateWindow();
+    }
+    else // mode 0: classic (exclusive) Qt fullscreen
+    {
+        if (wasBorderless)
+            setWindowFlag(Qt::FramelessWindowHint, false);
+        showFullScreen();
+    }
+
+    if (hasMenu)
+        menuBar()->setFixedHeight(0); // Don't use hide() as menubar actions stop working
+
+    fullscreenActive = true;
+}
+
+void MainWindow::toggleFullscreen()
+{
+    if (fullscreenActive)
+    {
+        setFullscreenMode(2); // back to windowed
+    }
+    else
+    {
+        // "FullscreenBorderless" (default on) decides the flavour used by the
+        // fullscreen hotkey: borderless windowed (1) vs classic Qt fullscreen (0).
+        setFullscreenMode(windowCfg.GetBool("FullscreenBorderless") ? 1 : 0);
     }
 }
 
 void MainWindow::onFullscreenToggled()
 {
     toggleFullscreen();
+}
+
+void MainWindow::onSetDisplayMode(int mode, int width, int height)
+{
+    setFullscreenMode(mode, width, height);
 }
 
 void MainWindow::onScreenEmphasisToggled()

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -122,6 +122,9 @@ public:
     void saveEnabled(bool enabled);
 
     void toggleFullscreen();
+    // mode: 0 = fullscreen (exclusive), 1 = borderless windowed, 2 = windowed.
+    // width/height (when > 0) size the window in windowed mode.
+    void setFullscreenMode(int mode, int width = 0, int height = 0);
 
     bool hasOpenGL() { return hasOGL; }
     GL::Context* getOGLContext();
@@ -252,6 +255,7 @@ private slots:
     void onUpdateVideoSettings(bool glchange);
 
     void onFullscreenToggled();
+    void onSetDisplayMode(int mode, int width, int height);
     void onScreenEmphasisToggled();
 
 private:
@@ -283,6 +287,13 @@ private:
     bool enabledSaved;
 
     bool focused;
+
+    // Fullscreen state. fullscreenActive tracks whether we are currently in
+    // fullscreen regardless of mode (Qt fullscreen or borderless windowed).
+    // savedGeometry holds the windowed geometry to restore when leaving
+    // borderless mode (which never enters Qt's WindowFullScreen state).
+    bool fullscreenActive = false;
+    QByteArray savedGeometry;
 
     EmuInstance* emuInstance;
     EmuThread* emuThread;

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -52,6 +52,16 @@ struct BgmEntry
     char Name[40];
 };
 
+// Display mode + window size the HD Collection launcher requests at game start.
+// mode: -1 = leave as-is; 0 = fullscreen, 1 = borderless, 2 = windowed.
+// width/height: 0 = unset (keep the current/previous window size).
+struct StartupWindowConfig
+{
+    int mode = -1;
+    int width = 0;
+    int height = 0;
+};
+
 enum EMidiState : u8 {
     Stopped = 0x00,
     LoadSequence  = 0x01,
@@ -208,13 +218,12 @@ public:
     // Desired display mode at game start, matching the HD Collection launcher's
     // display-mode setting: 0 = fullscreen (exclusive), 1 = borderless windowed,
     // 2 = windowed, -1 = no preference (leave the emulator window as-is).
-    virtual int startupWindowMode() {
-        return FullscreenOnStartup ? 1 : -1;
+    // Display mode + window size the launcher requests at game start. Returns a
+    // single struct so the override reads KingdomHeartsHDCollection::config()
+    // only once (it isn't cached, and this is only used once, at game start).
+    virtual StartupWindowConfig startupWindowConfig() {
+        return { FullscreenOnStartup ? 1 : -1, 0, 0 };
     }
-    // Window size (in pixels) the launcher requests; used to size the window in
-    // windowed mode. 0 means "unset" (keep the current/previous window size).
-    virtual int startupWindowWidth() { return 0; }
-    virtual int startupWindowHeight() { return 0; }
 
     virtual std::string localizationFilePath(std::string language) {return "";}
 

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -205,9 +205,16 @@ public:
     bool shouldExportTextures() {
         return ExportTextures;
     }
-    virtual bool shouldStartInFullscreen() {
-        return FullscreenOnStartup;
+    // Desired display mode at game start, matching the HD Collection launcher's
+    // display-mode setting: 0 = fullscreen (exclusive), 1 = borderless windowed,
+    // 2 = windowed, -1 = no preference (leave the emulator window as-is).
+    virtual int startupWindowMode() {
+        return FullscreenOnStartup ? 1 : -1;
     }
+    // Window size (in pixels) the launcher requests; used to size the window in
+    // windowed mode. 0 means "unset" (keep the current/previous window size).
+    virtual int startupWindowWidth() { return 0; }
+    virtual int startupWindowHeight() { return 0; }
 
     virtual std::string localizationFilePath(std::string language) {return "";}
 

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -447,38 +447,19 @@ std::string PluginKingdomHeartsDays::saveFilePath()
     return saveFilePathStr + saveFileName;
 }
 
-int PluginKingdomHeartsDays::startupWindowMode()
+StartupWindowConfig PluginKingdomHeartsDays::startupWindowConfig()
 {
     KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
     if (config == nullptr) {
-        return FullscreenOnStartup ? 1 : -1;
+        return { FullscreenOnStartup ? 1 : -1, 0, 0 };
     }
     // Launcher display mode: 0 = fullscreen, 1 = borderless, 2 = windowed.
-    int mode = config->windowMode;
+    StartupWindowConfig result;
+    result.mode = config->windowMode;
+    result.width = config->resolutionWidth;
+    result.height = config->resolutionHeight;
     delete config;
-    return mode;
-}
-
-int PluginKingdomHeartsDays::startupWindowWidth()
-{
-    KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
-    if (config == nullptr) {
-        return 0;
-    }
-    int width = config->resolutionWidth;
-    delete config;
-    return width;
-}
-
-int PluginKingdomHeartsDays::startupWindowHeight()
-{
-    KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
-    if (config == nullptr) {
-        return 0;
-    }
-    int height = config->resolutionHeight;
-    delete config;
-    return height;
+    return result;
 }
 
 void PluginKingdomHeartsDays::loadLocalization() {

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -447,13 +447,38 @@ std::string PluginKingdomHeartsDays::saveFilePath()
     return saveFilePathStr + saveFileName;
 }
 
-bool PluginKingdomHeartsDays::shouldStartInFullscreen() {
+int PluginKingdomHeartsDays::startupWindowMode()
+{
     KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
-    if (config == nullptr)
-    {
-        return FullscreenOnStartup;
+    if (config == nullptr) {
+        return FullscreenOnStartup ? 1 : -1;
     }
-    return config->windowMode == 0;
+    // Launcher display mode: 0 = fullscreen, 1 = borderless, 2 = windowed.
+    int mode = config->windowMode;
+    delete config;
+    return mode;
+}
+
+int PluginKingdomHeartsDays::startupWindowWidth()
+{
+    KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
+    if (config == nullptr) {
+        return 0;
+    }
+    int width = config->resolutionWidth;
+    delete config;
+    return width;
+}
+
+int PluginKingdomHeartsDays::startupWindowHeight()
+{
+    KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
+    if (config == nullptr) {
+        return 0;
+    }
+    int height = config->resolutionHeight;
+    delete config;
+    return height;
 }
 
 void PluginKingdomHeartsDays::loadLocalization() {

--- a/src/plugins/PluginKingdomHeartsDays.h
+++ b/src/plugins/PluginKingdomHeartsDays.h
@@ -28,7 +28,9 @@ public:
 
     void loadLocalization();
     std::string saveFilePath();
-    bool shouldStartInFullscreen() override;
+    int startupWindowMode() override;
+    int startupWindowWidth() override;
+    int startupWindowHeight() override;
     void onLoadROM() override;
     void onLoadState() override;
 

--- a/src/plugins/PluginKingdomHeartsDays.h
+++ b/src/plugins/PluginKingdomHeartsDays.h
@@ -28,9 +28,7 @@ public:
 
     void loadLocalization();
     std::string saveFilePath();
-    int startupWindowMode() override;
-    int startupWindowWidth() override;
-    int startupWindowHeight() override;
+    StartupWindowConfig startupWindowConfig() override;
     void onLoadROM() override;
     void onLoadState() override;
 

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -446,13 +446,38 @@ std::string PluginKingdomHeartsReCoded::saveFilePath()
     return saveFilePathStr + saveFileName;
 }
 
-bool PluginKingdomHeartsReCoded::shouldStartInFullscreen() {
+int PluginKingdomHeartsReCoded::startupWindowMode()
+{
     KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
-    if (config == nullptr)
-    {
-        return FullscreenOnStartup;
+    if (config == nullptr) {
+        return FullscreenOnStartup ? 1 : -1;
     }
-    return config->windowMode == 0;
+    // Launcher display mode: 0 = fullscreen, 1 = borderless, 2 = windowed.
+    int mode = config->windowMode;
+    delete config;
+    return mode;
+}
+
+int PluginKingdomHeartsReCoded::startupWindowWidth()
+{
+    KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
+    if (config == nullptr) {
+        return 0;
+    }
+    int width = config->resolutionWidth;
+    delete config;
+    return width;
+}
+
+int PluginKingdomHeartsReCoded::startupWindowHeight()
+{
+    KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
+    if (config == nullptr) {
+        return 0;
+    }
+    int height = config->resolutionHeight;
+    delete config;
+    return height;
 }
 
 void PluginKingdomHeartsReCoded::loadLocalization() {

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -446,38 +446,19 @@ std::string PluginKingdomHeartsReCoded::saveFilePath()
     return saveFilePathStr + saveFileName;
 }
 
-int PluginKingdomHeartsReCoded::startupWindowMode()
+StartupWindowConfig PluginKingdomHeartsReCoded::startupWindowConfig()
 {
     KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
     if (config == nullptr) {
-        return FullscreenOnStartup ? 1 : -1;
+        return { FullscreenOnStartup ? 1 : -1, 0, 0 };
     }
     // Launcher display mode: 0 = fullscreen, 1 = borderless, 2 = windowed.
-    int mode = config->windowMode;
+    StartupWindowConfig result;
+    result.mode = config->windowMode;
+    result.width = config->resolutionWidth;
+    result.height = config->resolutionHeight;
     delete config;
-    return mode;
-}
-
-int PluginKingdomHeartsReCoded::startupWindowWidth()
-{
-    KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
-    if (config == nullptr) {
-        return 0;
-    }
-    int width = config->resolutionWidth;
-    delete config;
-    return width;
-}
-
-int PluginKingdomHeartsReCoded::startupWindowHeight()
-{
-    KingdomHeartsHDCollection::KHMareConfig* config = KingdomHeartsHDCollection::config();
-    if (config == nullptr) {
-        return 0;
-    }
-    int height = config->resolutionHeight;
-    delete config;
-    return height;
+    return result;
 }
 
 void PluginKingdomHeartsReCoded::loadLocalization() {

--- a/src/plugins/PluginKingdomHeartsReCoded.h
+++ b/src/plugins/PluginKingdomHeartsReCoded.h
@@ -27,9 +27,7 @@ public:
 
     void loadLocalization();
     std::string saveFilePath();
-    int startupWindowMode() override;
-    int startupWindowWidth() override;
-    int startupWindowHeight() override;
+    StartupWindowConfig startupWindowConfig() override;
     void onLoadROM() override;
 
     std::string gameFolderName() override;

--- a/src/plugins/PluginKingdomHeartsReCoded.h
+++ b/src/plugins/PluginKingdomHeartsReCoded.h
@@ -27,7 +27,9 @@ public:
 
     void loadLocalization();
     std::string saveFilePath();
-    bool shouldStartInFullscreen() override;
+    int startupWindowMode() override;
+    int startupWindowWidth() override;
+    int startupWindowHeight() override;
     void onLoadROM() override;
 
     std::string gameFolderName() override;


### PR DESCRIPTION
## What

The Kingdom Hearts HD Collection launcher lets the player pick a display mode (fullscreen / borderless / windowed) and a resolution. Until now the emulator only checked for fullscreen (`windowMode == 0`) and ignored the rest, so "borderless" and "windowed" behaved like fullscreen.

This reads the launcher's `windowMode` and resolution and applies them when a game starts:

| Launcher mode | windowMode | Behaviour |
|---|---|---|
| Fullscreen | 0 | Exclusive fullscreen |
| Borderless | 1 | Borderless windowed (no alt-tab flicker) |
| Windowed | 2 | Windowed, sized to the launcher's resolution |

## How

- `Plugin::shouldStartInFullscreen()` (bool) is replaced by `startupWindowMode()` (0/1/2, or -1 for "no preference") plus `startupWindowWidth()` / `startupWindowHeight()`. Implemented for KH 358/2 Days and Re:Coded by reading the launcher's `KHMareConfig`.
- `EmuThread` emits a new `windowSetDisplayMode(mode, width, height)` signal at game start.
- `MainWindow::setFullscreenMode(mode, width, height)` applies it:
  - **Borderless** uses a frameless window sized 1px past the monitor edge, which stops Windows from promoting it to "fullscreen optimization" (DirectFlip) — the cause of alt-tab flicker on borderless windows. The extra row is off-screen and never visible.
  - **Windowed** centers a window at the launcher's resolution.
- New `FullscreenBorderless` option (default on) chooses borderless vs classic Qt fullscreen for the in-app fullscreen hotkey.

## Notes
- The fullscreen hotkey and the `-f` CLI flag keep working.