### PR TITLE
CI: fix BSD/Windows/macOS workflow regressions and re-align with upstream

### DIFF
--- a/.github/workflows/build-bsd.yml
+++ b/.github/workflows/build-bsd.yml
@@ -27,9 +27,6 @@ jobs:
         include:
           - os: freebsd
             os_name: FreeBSD
-            # CMake's autorcc for Qt tries to lock files, so we need to
-            # start lockd for NFS, otherwise the build will fail.
-            prepare_vm: service lockd onestart
             install_deps: >
               pkg install -y cmake kf6-extra-cmake-modules pkgconf ninja
               qt6-base qt6-multimedia qt6-svg sdl2 libarchive zstd enet
@@ -59,17 +56,18 @@ jobs:
             install_deps: >
               pkg_add -v cmake kf6-extra-cmake-modules pkgconf ninja
               qt6-qtbase qt6-qtmultimedia qt6-qtsvg sdl2 libarchive zstd
-              enet faad flac lua-5.4.7
+              enet faad flac lua%5.4
 
 
     name: ${{ matrix.os_name }} / ${{ matrix.arch }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     defaults:
       run:
         shell: ${{ matrix.os }} {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       name: Check out sources
 
     - name: Start ${{ matrix.os_name }} VM
@@ -93,14 +91,12 @@ jobs:
       run: ${{ matrix.install_deps }}
 
     - name: Configure
-      run: |
-        cd $GITHUB_WORKSPACE
-        cmake -B build -G Ninja -DMELONDS_EMBED_BUILD_INFO=ON
+      run: >
+        cmake -S $GITHUB_WORKSPACE -B /tmp/build -G Ninja
+        -DMELONDS_EMBED_BUILD_INFO=ON
 
     - name: Build
-      run: |
-        cd $GITHUB_WORKSPACE
-        cmake --build build
+      run: cmake --build /tmp/build
 
     - name: Preparing artifacts
       run: |
@@ -110,13 +106,13 @@ jobs:
         touch ./dist/roms/DELETE_ME
         mkdir -p ./dist/assets
         touch ./dist/assets/DELETE_ME
-        cp build/melonDS ./dist/MelonMix
+        cp /tmp/build/melonDS ./dist/MelonMix
         cp ./res/scripts/MelonMix_KHDays.sh       ./dist/MelonMix_KHDays.sh
         cp ./res/scripts/MelonMix_KHReCoded.sh    ./dist/MelonMix_KHReCoded.sh
         cp ./res/scripts/MelonMix_GameSelector.sh ./dist/MelonMix_GameSelector.sh
 
     - name: Upload binary
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: MelonMix-${{ matrix.os }}-${{ matrix.arch }}
         path: dist

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -87,13 +87,13 @@ jobs:
     continue-on-error: true
     steps:
       - name: Download x86_64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: MelonMix-macOS-x86_64.zip
           path: x86_64
           skip-decompress: true
       - name: Download arm64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: MelonMix-macOS-arm64.zip
           path: arm64

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -26,6 +26,7 @@ jobs:
 
     name: ${{ matrix.arch }}
     runs-on: macos-26
+    timeout-minutes: 90
 
     env:
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
@@ -84,7 +85,7 @@ jobs:
     name: Universal binary
     needs: [build-macos]
     runs-on: macos-26
-    continue-on-error: true
+    timeout-minutes: 20
     steps:
       - name: Download x86_64
         uses: actions/download-artifact@v8
@@ -114,3 +115,4 @@ jobs:
         with:
           name: MelonMix-macOS-universal
           path: MelonMix-macOS-universal.zip
+          archive: false

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -30,6 +30,7 @@ jobs:
 
     name: ${{ matrix.arch.name }}
     runs-on: ${{ matrix.arch.runner }}
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -30,6 +30,7 @@ jobs:
 
     name: ${{ matrix.arch.name }}
     runs-on: ${{ matrix.arch.image }}
+    timeout-minutes: 90
     env:
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
     steps:
@@ -39,8 +40,8 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/vcpkg_cache
-        key: vcpkg-x86_64-mingw-${{ hashFiles('vcpkg.json') }}
-        restore-keys: vcpkg-x86_64-mingw-
+        key: vcpkg-${{ matrix.arch.name }}-windows-${{ hashFiles('vcpkg.json') }}
+        restore-keys: vcpkg-${{ matrix.arch.name }}-windows-
     - name: Set up vcpkg
       uses: lukka/run-vcpkg@v11
       with:


### PR DESCRIPTION
Several CI checks have been failing or stalling on `master` itself — all of them bugs in the workflow files rather than in any branch's source. The recurring cause is the June "Bringing latest workflow changes from melonDS" sync (`59210ee`), which updated some lines but left paired settings stale. This goes through all four workflows and re-aligns them with upstream melonDS.

### BSD — FreeBSD build stall (was running to the 360-minute cap)

The FreeBSD job hung in Build right after Qt's AUTOMOC/AUTOUIC step. Qt's autogen takes file locks on the NFS-mounted workspace, and the FreeBSD NFS lock stack isn't reliably up; the old workaround (`prepare_vm: service lockd onestart`) only started `lockd`, which itself blocks waiting on `statd`/`rpcbind`.

Fixed the way upstream does: build in VM-local `/tmp/build` instead of on the NFS share, which avoids the lock path entirely, and dropped the `lockd` workaround. Also bumped `checkout@v4 → @v6` and `upload-artifact@v4 → @v7` to match upstream, and added `timeout-minutes: 60` so a future hang fails in an hour instead of six.

### BSD — OpenBSD Lua dependency

The OpenBSD job pinned the exact patch release `lua-5.4.7`, which is dropped from the package mirror whenever OpenBSD ships a new 5.4 point release, so `pkg_add lua-5.4.7` started failing at the dependency step. Switched to the branch selector `lua%5.4`, which always resolves to the current 5.4 build. (Lua on OpenBSD is KHMelonMix-specific — upstream installs none — so this is our own fix, not an import.)

### Windows — vcpkg cache key mismatch (~45–50 min wasted per run)

The restore step was still keyed on the old hardcoded `vcpkg-x86_64-mingw-` prefix while the save step writes `vcpkg-<arch>-windows-`. The two never match, so the cache missed every run and vcpkg rebuilt all dependencies from source every time — and a stuck dependency build can hit the 360-minute cap. Keyed the restore on `vcpkg-${{ matrix.arch.name }}-windows-` to match the save step and upstream, and added `timeout-minutes: 90`.

### macOS — universal binary assembly (silent failure)

The per-arch builds succeed and upload their artifacts; only the `universal-binary` combine job failed, at `unzip x86_64/*.zip`. Upstream uploads with `upload-artifact@v7` + `archive: false` and downloads with `download-artifact@v8` + `skip-decompress: true`; the sync brought the upload change and the download options but left `download-artifact` at `@v4`. That v4/v7 mismatch leaves no `.zip` where the combine step looks. Bumped both downloads to `@v8` to complete the import.

That break went unnoticed because the job was `continue-on-error: true`, so it failed silently while the workflow reported green. Dropped `continue-on-error` so a real break fails the run, added `archive: false` to the universal upload to match the per-arch uploads and upstream, and added timeouts to both macOS jobs.

### Notes

- I left the split `cache/restore` + `cache/save` actions as-is (rather than a combined `cache@v4`) because upstream uses the split form; switching would create fresh drift. The bug was the wrong key, not the split.
- The FreeBSD/NetBSD `flac` + `lua54` and OpenBSD `flac` + Lua dependencies are kept — KHMelonMix needs FLAC (BGM) and Lua (plugins); upstream omits them only because it lacks those features.
- Added `timeout-minutes` to every job across all four workflows (60 BSD / 90 macOS, Windows, Ubuntu / 20 universal-combine) as conservative safety nets well under the 360-minute default; tune as you see fit. Left Ubuntu's existing `continue-on-error` in place since that's an intentional policy for the AppImage build.

These workflow changes can only really be validated by running them, which pushing this branch does — please watch the checks on this PR.
