### PR TITLE
Fix the texture index.ini never loading on Windows

### DIFF
--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -685,6 +685,8 @@ std::map<std::string, TextureEntry>& Plugin::getTexturesIndex() {
                 }
             }
         }
+
+        Platform::CloseFile(f);
     }
 
     texturesIndex = _texturesIndex;

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -579,7 +579,10 @@ std::string Plugin::textureIndexFilePath() {
         return "";
     }
 
-    return fullPath.string();
+    // u8string(), not string(): this is handed to Platform::OpenLocalFile, which decodes it
+    // as UTF-8. On Windows string() would yield the ANSI code page instead, and any accent
+    // in the path would come out mangled.
+    return fullPath.u8string();
 }
 std::map<std::string, TextureEntry>& Plugin::getTexturesIndex() {
     if (!texturesIndex.empty()) {
@@ -999,7 +1002,7 @@ void Plugin::loadBgmRedirections() {
             iniFilePath = fullPath0;
         }
     }
-    Platform::FileHandle* file = Platform::OpenLocalFile(iniFilePath.string().c_str(), Platform::FileMode::ReadText);
+    Platform::FileHandle* file = Platform::OpenLocalFile(iniFilePath.u8string().c_str(), Platform::FileMode::ReadText);
     if (file) {
         _BgmRedirectors.clear();
 

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -687,6 +687,15 @@ std::map<std::string, TextureEntry>& Plugin::getTexturesIndex() {
         }
 
         Platform::CloseFile(f);
+
+        if (_texturesIndex.empty()) {
+            errorLog("Texture index %s was read, but none of its lines could be parsed", indexFilePath.c_str());
+        }
+    }
+    else {
+        // textureIndexFilePath() only hands back a path it has just found on disk, so a
+        // failure here means index.ini is present but unreadable, not that there is none.
+        errorLog("Texture index %s exists but could not be opened", indexFilePath.c_str());
     }
 
     texturesIndex = _texturesIndex;

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -604,7 +604,10 @@ std::map<std::string, TextureEntry>& Plugin::getTexturesIndex() {
             if (!Platform::FileReadLine(linebuf, 1024, f))
                 break;
 
-            int ret = sscanf(linebuf, "%31[A-Za-z_0-9\\-.]=%[^\t\r\n]", entryname, entryval);
+            // '-' must stay last in the scanset. Anywhere else the CRT reads it as a range
+            // delimiter: glibc ignores the reversed "\-." range, but the UCRT swaps it into
+            // '.'..'\\', which matches '=' and makes every line fail to parse.
+            int ret = sscanf(linebuf, "%31[A-Za-z0-9_.\\-]=%[^\t\r\n]", entryname, entryval);
             entryname[31] = '\0';
             if (ret < 2) continue;
 

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -569,6 +569,16 @@ std::string trim(const std::string& str) {
     // Return the substring that excludes leading and trailing whitespace
     return str.substr(start, end - start + 1);
 }
+const char* Plugin::skipUtf8Bom(const char* line) {
+    if ((unsigned char)line[0] == 0xEF &&
+        (unsigned char)line[1] == 0xBB &&
+        (unsigned char)line[2] == 0xBF)
+    {
+        return line + 3;
+    }
+
+    return line;
+}
 std::string Plugin::textureIndexFilePath() {
     std::string filename = "index.ini";
     std::filesystem::path _assetsFolderPath = gameAssetsFolderPath();
@@ -608,19 +618,11 @@ std::map<std::string, TextureEntry>& Plugin::getTexturesIndex() {
             if (!Platform::FileReadLine(linebuf, 1024, f))
                 break;
 
-            char* line = linebuf;
+            const char* line = linebuf;
             if (firstLine)
             {
                 firstLine = false;
-
-                // Windows editors (Notepad among them) prefix UTF-8 files with a BOM, which
-                // is not part of the first entry's name.
-                if ((unsigned char)line[0] == 0xEF &&
-                    (unsigned char)line[1] == 0xBB &&
-                    (unsigned char)line[2] == 0xBF)
-                {
-                    line += 3;
-                }
+                line = skipUtf8Bom(line);
             }
 
             // '-' must stay last in the scanset. Anywhere else the CRT reads it as a range
@@ -1030,6 +1032,7 @@ void Plugin::loadBgmRedirections() {
             return std::string(start, end - start + 1);
         };
 
+        bool firstLine = true;
         while (!Platform::IsEndOfFile(file))
         {
             if (!Platform::FileReadLine(linebuf, 1024, file))
@@ -1044,13 +1047,20 @@ void Plugin::loadBgmRedirections() {
                 }
             }
 
-            if (strlen(linebuf) == 0
-                || linebuf[0] == '#'
-                || linebuf[0] == ';') {
+            const char* line = linebuf;
+            if (firstLine)
+            {
+                firstLine = false;
+                line = skipUtf8Bom(line);
+            }
+
+            if (strlen(line) == 0
+                || line[0] == '#'
+                || line[0] == ';') {
                 continue;
             }
 
-            if (sscanf(linebuf, "%[^=]=%[^\n]", entryname, entryval) == 2) {
+            if (sscanf(line, "%[^=]=%[^\n]", entryname, entryval) == 2) {
                 _BgmRedirectors[trim_str(entryname)] = trim_str(entryval);
             }
         }

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -599,15 +599,31 @@ std::map<std::string, TextureEntry>& Plugin::getTexturesIndex() {
         char linebuf[1024];
         char entryname[32];
         char entryval[1024];
+        bool firstLine = true;
         while (!Platform::IsEndOfFile(f))
         {
             if (!Platform::FileReadLine(linebuf, 1024, f))
                 break;
 
+            char* line = linebuf;
+            if (firstLine)
+            {
+                firstLine = false;
+
+                // Windows editors (Notepad among them) prefix UTF-8 files with a BOM, which
+                // is not part of the first entry's name.
+                if ((unsigned char)line[0] == 0xEF &&
+                    (unsigned char)line[1] == 0xBB &&
+                    (unsigned char)line[2] == 0xBF)
+                {
+                    line += 3;
+                }
+            }
+
             // '-' must stay last in the scanset. Anywhere else the CRT reads it as a range
             // delimiter: glibc ignores the reversed "\-." range, but the UCRT swaps it into
             // '.'..'\\', which matches '=' and makes every line fail to parse.
-            int ret = sscanf(linebuf, "%31[A-Za-z0-9_.\\-]=%[^\t\r\n]", entryname, entryval);
+            int ret = sscanf(line, "%31[A-Za-z0-9_.\\-]=%[^\t\r\n]", entryname, entryval);
             entryname[31] = '\0';
             if (ret < 2) continue;
 

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -425,6 +425,11 @@ public:
 
     static void errorLog(const char* format, ...);
 
+    // Returns line advanced past a UTF-8 BOM, if it has one. Only meaningful on the first
+    // line of a file. Windows editors (Notepad among them) write that BOM; it is not part
+    // of the first entry's name, and leaving it in makes the entry fail to parse.
+    static const char* skipUtf8Bom(const char* line);
+
     u32 LastMainRAM[0xFFFFFF];
     bool MainRAMState[0xFFFFFF];
 

--- a/src/plugins/PluginHarvestMoonDsCute.cpp
+++ b/src/plugins/PluginHarvestMoonDsCute.cpp
@@ -46,12 +46,20 @@ void PluginHarvestMoonDsCute::loadLocalization() {
         char linebuf[1024];
         char entryname[32];
         char entryval[1024];
+        bool firstLine = true;
         while (!Platform::IsEndOfFile(f))
         {
             if (!Platform::FileReadLine(linebuf, 1024, f))
                 break;
 
-            int ret = sscanf(linebuf, "%31[A-Za-z_0-9]=%[^\t\r\n]", entryname, entryval);
+            const char* line = linebuf;
+            if (firstLine)
+            {
+                firstLine = false;
+                line = skipUtf8Bom(line);
+            }
+
+            int ret = sscanf(line, "%31[A-Za-z_0-9]=%[^\t\r\n]", entryname, entryval);
             entryname[31] = '\0';
             if (ret < 2) continue;
 

--- a/src/plugins/PluginHarvestMoonDsCute.cpp
+++ b/src/plugins/PluginHarvestMoonDsCute.cpp
@@ -146,7 +146,8 @@ std::string PluginHarvestMoonDsCute::localizationFilePath(std::string language) 
     std::filesystem::path _assetsFolderPath = gameAssetsFolderPath();
     std::filesystem::path fullPath = _assetsFolderPath / "localization" / assetsRegionSubfolderName / filename;
     if (std::filesystem::exists(fullPath)) {
-        return fullPath.string();
+        // u8string(): this is handed to Platform::OpenLocalFile, which decodes it as UTF-8.
+        return fullPath.u8string();
     }
 
     return "";

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -488,12 +488,20 @@ void PluginKingdomHeartsDays::loadLocalization() {
         char linebuf[1024];
         char entryname[32];
         char entryval[1024];
+        bool firstLine = true;
         while (!Platform::IsEndOfFile(f))
         {
             if (!Platform::FileReadLine(linebuf, 1024, f))
                 break;
 
-            int ret = sscanf(linebuf, "%31[A-Za-z_0-9]=%[^\t\r\n]", entryname, entryval);
+            const char* line = linebuf;
+            if (firstLine)
+            {
+                firstLine = false;
+                line = skipUtf8Bom(line);
+            }
+
+            int ret = sscanf(line, "%31[A-Za-z_0-9]=%[^\t\r\n]", entryname, entryval);
             entryname[31] = '\0';
             if (ret < 2) continue;
 

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -2959,7 +2959,8 @@ std::string PluginKingdomHeartsDays::localizationFilePath(std::string language) 
     std::filesystem::path _assetsFolderPath = gameAssetsFolderPath();
     std::filesystem::path fullPath = _assetsFolderPath / "localization" / assetsRegionSubfolderName / filename;
     if (std::filesystem::exists(fullPath)) {
-        return fullPath.string();
+        // u8string(): this is handed to Platform::OpenLocalFile, which decodes it as UTF-8.
+        return fullPath.u8string();
     }
 
     return "";

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -493,12 +493,20 @@ void PluginKingdomHeartsReCoded::loadLocalization() {
         char linebuf[1024];
         char entryname[32];
         char entryval[1024];
+        bool firstLine = true;
         while (!Platform::IsEndOfFile(f))
         {
             if (!Platform::FileReadLine(linebuf, 1024, f))
                 break;
 
-            int ret = sscanf(linebuf, "%31[A-Za-z_0-9]=%[^\t\r\n]", entryname, entryval);
+            const char* line = linebuf;
+            if (firstLine)
+            {
+                firstLine = false;
+                line = skipUtf8Bom(line);
+            }
+
+            int ret = sscanf(line, "%31[A-Za-z_0-9]=%[^\t\r\n]", entryname, entryval);
             entryname[31] = '\0';
             if (ret < 2) continue;
 

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -2964,7 +2964,8 @@ std::string PluginKingdomHeartsReCoded::localizationFilePath(std::string languag
     std::filesystem::path _assetsFolderPath = gameAssetsFolderPath();
     std::filesystem::path fullPath = _assetsFolderPath / "localization" / filename;
     if (std::filesystem::exists(fullPath)) {
-        return fullPath.string();
+        // u8string(): this is handed to Platform::OpenLocalFile, which decodes it as UTF-8.
+        return fullPath.u8string();
     }
 
     return "";


### PR DESCRIPTION
## The bug

`Plugin::getTexturesIndex()` parses `assets/<game>/textures/index.ini`, but on Windows not one line of it ever makes it through. The file is found and opened fine — every line simply fails to parse, so the index comes out empty and nothing configured through it takes effect.

The scanset is the culprit:

```c
sscanf(linebuf, "%31[A-Za-z_0-9\-.]=%[^\t\r\n]", entryname, entryval);
```

It ends in `\-.`, which the C runtime reads as a character range from `\` (0x5C) to `.` (0x2E) — a reversed one. glibc explicitly guards against reversed ranges and falls back to matching `\`, `-` and `.` literally, which is what was intended, so Linux parses the file correctly. The UCRT instead swaps the bounds into `.`..`\`, a range that contains `=`. `entryname` then swallows the whole line, `sscanf` returns 1, and every line is dropped by the `ret < 2` check.

Windows builds are affected because the release presets target the UCRT (clang++). MinGW builds use their own `scanf` and are not, which is why this only reproduces in the official builds and not in a local MSYS2 one.

Compiling the exact format string with clang++ against the UCRT:

```
current:  ret=1  name='mainmenu_bg=mainmenu_bg.png'  val=''
fixed:    ret=2  name='mainmenu_bg'                  val='mainmenu_bg.png'
```

## The commits

Each one stands alone:

1. **Fix texture index.ini never loading on Windows** — move `-` to the end of the scanset, where the C standard requires it to be a literal. The resulting character set is identical to the one glibc was already computing, so Linux behaviour does not change.

2. **Skip the UTF-8 BOM when parsing the texture index.ini** — Notepad and friends prefix UTF-8 files with a BOM, which silently costs the first entry.

3. **Fix plugin asset paths breaking on non-ASCII directories on Windows** — `Platform::OpenLocalFile` decodes UTF-8, but the plugins were feeding it `std::filesystem::path::string()`, which on Windows is the ANSI code page: `é` comes out as the single byte `E9` rather than `C3 A9`, Qt substitutes U+FFFD and `QFile` no longer finds the file. Anyone with an accent in their install path silently gets no textures, no bgm redirections and no localization. Only the Qt-bound paths are switched to `u8string()`; texture bitmaps go through `stbi_load`/`fopen`, which does want the ANSI code page on Windows, so those keep using `string()`.

4. **Skip the UTF-8 BOM in the remaining ini readers too** — bgm.ini and the localization files share the same loop, via a small `Plugin::skipUtf8Bom` helper.

5. **Close the texture index file handle after parsing it** — `getTexturesIndex()` was the only ini reader that never closed its handle.

6. **Report a texture index that exists but yields nothing** — the failure was completely silent, which is most of why this took so long to pin down. A missing index.ini stays silent, since having none is normal.

## Testing

- Built with the `release-windows-x86_64` preset (clang++/UCRT) and confirmed the fixed scanset is present in the binary and the broken one is gone.
- The scanset, the BOM and the `path::string()` encoding were each verified against the real UCRT, and the scanset against MinGW too, to confirm the fix is a no-op there.
- Not yet exercised end-to-end with a ROM and a real index.ini — worth a second pair of eyes on that.