### PR TITLE
Localization system and filesystem explorer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,25 @@ add_library(core STATIC
     plugins/PluginTemplateLua.cpp
     plugins/KingdomHeartsHDCollection.cpp
 
+    plugins/localization/cakp.cpp
+    plugins/localization/cakp.h
+    plugins/localization/lang.cpp
+    plugins/localization/lang.h
+    plugins/localization/lzss.cpp
+    plugins/localization/lzss.h
+    plugins/localization/nds.cpp
+    plugins/localization/nds.h
+    plugins/localization/p2.cpp
+    plugins/localization/p2.h
+    plugins/localization/rompatcher.cpp
+    plugins/localization/rompatcher.h
+    plugins/localization/strings.cpp
+    plugins/localization/strings.h
+    plugins/localization/stringtable.cpp
+    plugins/localization/stringtable.h
+    plugins/localization/utils.cpp
+    plugins/localization/utils.h
+
     sha1/sha1.c
     tiny-AES-c/aes.c
     xxhash/xxhash.c

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -21,6 +21,14 @@ set(SOURCES_QT_SDL
     InputConfig/InputConfigDialog.cpp
     InputConfig/MapButton.h
     InputConfig/resources/ds.qrc
+    localization/ExportResult.h
+    localization/FileEntry.h
+    localization/FileSystemDialog.cpp
+    localization/FileSystemDialog.h
+    localization/LocUtils.cpp
+    localization/LocUtils.h
+    localization/Worker.cpp
+    localization/Worker.h
     MainWindow/MainWindowSettings.cpp
     MainWindow/CutsceneVideoView.cpp
     MainWindow/PauseMenuOverlay.cpp
@@ -206,7 +214,9 @@ endif()
 
 target_include_directories(melonDS PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}"
-    "${CMAKE_CURRENT_SOURCE_DIR}/..")
+    "${CMAKE_CURRENT_SOURCE_DIR}/.."
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../plugins")
+
 target_include_directories(melonDS PRIVATE ${LUA_INCLUDE_DIR})
 
 if (USE_QT6)

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -71,6 +71,7 @@
 #include "RAMInfoDialog.h"
 #include "TitleManagerDialog.h"
 #include "PowerManagement/PowerManagementDialog.h"
+#include "localization/FileSystemDialog.h"
 
 #include "Platform.h"
 #include "Config.h"
@@ -464,6 +465,9 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
 
                 actRAMInfo = menu->addAction("RAM search");
                 connect(actRAMInfo, &QAction::triggered, this, &MainWindow::onRAMInfo);
+
+                actFilesystemMenu = menu->addAction("Filesystem / Localization");
+                connect(actFilesystemMenu, &QAction::triggered, this, &MainWindow::onOpenFilesystemMenu);
 
                 actTitleManager = menu->addAction("Manage DSi titles");
                 connect(actTitleManager, &QAction::triggered, this, &MainWindow::onOpenTitleManager);
@@ -2711,3 +2715,17 @@ void MainWindow::onUpdateVideoSettings(bool glchange)
         emuThread->emuUnpause();
     }
 }
+
+
+void MainWindow::onOpenFilesystemMenu()
+{
+    emuThread->emuPause();
+    FileSystemDialog* dlg = FileSystemDialog::openDlg(this);
+    connect(dlg, &FileSystemDialog::finished, this, &MainWindow::onFilesystemMenuFinished);
+}
+
+void MainWindow::onFilesystemMenuFinished(int res)
+{
+    emuThread->emuUnpause();
+}
+

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -243,6 +243,9 @@ private slots:
     void onChangeLimitFramerate(bool checked);
     void onChangeAudioSync(bool checked);
 
+    void onOpenFilesystemMenu();
+    void onFilesystemMenuFinished(int res);
+
     void onTitleUpdate(QString title);
 
     void onEmuStart();
@@ -347,6 +350,7 @@ public:
     QAction* actSetupCheats;
     QAction* actROMInfo;
     QAction* actRAMInfo;
+    QAction* actFilesystemMenu;
     QAction* actTitleManager;
     QAction* actMPNewInstance;
     QAction* actLANStartHost;

--- a/src/frontend/qt_sdl/localization/ExportResult.h
+++ b/src/frontend/qt_sdl/localization/ExportResult.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QMetaType>
+#include <QString>
+#include <QVector>
+
+struct NdsExportedFile
+{
+    QString path;
+    int stringCount = 0;
+};
+
+struct NdsExportResult
+{
+    QVector<NdsExportedFile> files;
+    bool success = false;
+
+    int totalStrings() const
+    {
+        int total = 0;
+        for (const NdsExportedFile& file : files)
+            total += file.stringCount;
+        return total;
+    }
+};
+
+Q_DECLARE_METATYPE(NdsExportedFile)
+Q_DECLARE_METATYPE(NdsExportResult)

--- a/src/frontend/qt_sdl/localization/FileEntry.h
+++ b/src/frontend/qt_sdl/localization/FileEntry.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <QMetaType>
+#include <QString>
+#include <QVector>
+
+struct NdsFileEntry
+{
+    QString path;
+    QString type;
+    quint64 size = 0;
+};
+
+using NdsFileEntryList = QVector<NdsFileEntry>;
+
+Q_DECLARE_METATYPE(NdsFileEntry)
+Q_DECLARE_METATYPE(NdsFileEntryList)

--- a/src/frontend/qt_sdl/localization/FileSystemDialog.cpp
+++ b/src/frontend/qt_sdl/localization/FileSystemDialog.cpp
@@ -1,0 +1,55 @@
+#include "FileSystemDialog.h"
+
+#include <QFileDialog>
+#include <QVBoxLayout>
+
+#include "Platform.h"
+#include "main.h"
+
+#include "LocUtils.h"
+
+using namespace melonDS::Platform;
+namespace Platform = melonDS::Platform;
+
+FileSystemDialog* FileSystemDialog::currentDlg = nullptr;
+
+
+FileSystemDialog::FileSystemDialog(QWidget* parent)
+    : QDialog(parent)
+{
+    emuInstance = ((MainWindow*)parent)->getEmuInstance();
+
+    QVBoxLayout* layout = new QVBoxLayout(this);
+
+    auto* locUtils = new LocUtils(this);
+    auto* cart = emuInstance->getNDS()->GetNDSCart();
+    locUtils->loadRomData((uint8_t*)cart->GetROM(), cart->GetROMLength());
+
+    layout->addWidget(locUtils);
+
+    setWindowTitle("File System - melonDS");
+    setAttribute(Qt::WA_DeleteOnClose);
+}
+
+FileSystemDialog::~FileSystemDialog()
+{
+}
+
+void FileSystemDialog::done(int r)
+{
+    QDialog::done(r);
+    closeDlg();
+}
+
+FileSystemDialog* FileSystemDialog::openDlg(QWidget* parent)
+{
+    if (currentDlg)
+    {
+        currentDlg->activateWindow();
+        return currentDlg;
+    }
+
+    currentDlg = new FileSystemDialog(parent);
+    currentDlg->open();
+    return currentDlg;
+}

--- a/src/frontend/qt_sdl/localization/FileSystemDialog.h
+++ b/src/frontend/qt_sdl/localization/FileSystemDialog.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <QDialog>
+
+class EmuInstance;
+class FileSystemDialog;
+
+class FileSystemDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit FileSystemDialog(QWidget* parent);
+    ~FileSystemDialog();
+
+    static FileSystemDialog* currentDlg;
+    static FileSystemDialog* openDlg(QWidget* parent);
+
+    static void closeDlg()
+    {
+        currentDlg = nullptr;
+    }
+
+private slots:
+    void done(int r);
+
+private:
+    EmuInstance* emuInstance = nullptr;
+};

--- a/src/frontend/qt_sdl/localization/LocUtils.cpp
+++ b/src/frontend/qt_sdl/localization/LocUtils.cpp
@@ -1,0 +1,788 @@
+#include "LocUtils.h"
+
+#include <QAction>
+#include <QClipboard>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QGuiApplication>
+#include <QHeaderView>
+#include <QDir>
+#include <QMenu>
+#include <QMessageBox>
+#include <QRegularExpression>
+#include <QSet>
+#include <QStatusBar>
+#include <QTextCursor>
+#include <QTreeWidgetItem>
+
+#include "Worker.h"
+
+#include "localization/lang.h"
+#include "localization/strings.h"
+
+namespace
+{
+    constexpr int ColumnName = 0;
+    constexpr int ColumnSize = 1;
+    constexpr int ColumnType = 2;
+
+    constexpr int PathRole   = Qt::UserRole + 1;
+    constexpr int SizeRole   = Qt::UserRole + 2;
+    constexpr int IsFileRole = Qt::UserRole + 3;
+
+    void setExpandedRecursive(QTreeWidgetItem* item, bool expanded)
+    {
+        item->setExpanded(expanded);
+        for (int i = 0; i < item->childCount(); ++i)
+            setExpandedRecursive(item->child(i), expanded);
+    }
+
+    QString humanSize(quint64 bytes)
+    {
+        if (bytes < 1024)
+            return QString("%1 B").arg(bytes);
+        if (bytes < 1024ull * 1024ull)
+            return QString("%1 KB").arg(bytes / 1024.0, 0, 'f', 1);
+        return QString("%1 MB").arg(bytes / (1024.0 * 1024.0), 0, 'f', 1);
+    }
+}
+
+LocUtils::LocUtils(QWidget* parent)
+    : QWidget(parent)
+{
+    ui.setupUi(this);
+
+    auto font = QFont(ui.textEditLog->font());
+    font.setPointSize(8);
+    ui.textEditLog->setFont(font);
+
+    ui.splitterMain->setStretchFactor(0, 2);   // tree
+    ui.splitterMain->setStretchFactor(1, 3);   // log
+
+    ui.treeFiles->header()->setSectionResizeMode(ColumnName, QHeaderView::Interactive);
+    ui.treeFiles->header()->setStretchLastSection(false);
+    ui.treeFiles->setColumnWidth(ColumnName, 260);
+    ui.treeFiles->setColumnWidth(ColumnSize, 80);
+
+    qRegisterMetaType<NdsFileEntryList>("NdsFileEntryList");
+    qRegisterMetaType<NdsExportResult>("NdsExportResult");
+
+    m_worker = new Worker();
+    m_worker->moveToThread(&m_workerThread);
+
+    connect(m_worker, &Worker::log, this, &LocUtils::appendLog);
+    connect(m_worker, &Worker::romLoaded, this, &LocUtils::onRomLoaded);
+    connect(m_worker, &Worker::filesystemListed,  this, &LocUtils::onFilesystemListed);
+    connect(m_worker, &Worker::taskFinished, this, &LocUtils::onTaskFinished);
+    connect(m_worker, &Worker::exportFinished, this, &LocUtils::onExportFinished);
+
+    connect(this, &LocUtils::requestLoadRom, m_worker, &Worker::loadRom);
+    connect(this, &LocUtils::requestLoadRomData, m_worker, &Worker::loadRomData);
+    connect(this, &LocUtils::requestExtractP2Files, m_worker, &Worker::extractP2Files);
+    connect(this, &LocUtils::requestExtractZFiles, m_worker, &Worker::extractZFiles);
+    connect(this, &LocUtils::requestExtractRawFiles, m_worker, &Worker::extractRawFiles);
+    connect(this, &LocUtils::requestExportStrings, m_worker, &Worker::exportStrings);
+
+    ui.comboLanguage->addItem("All", 0);
+
+    for (int i = 0; i < ndsloc::Language::LANG_COUNT; i++)
+    {
+        auto langName = ndsloc::getLanguageName(static_cast<ndsloc::Language>(i));
+        ui.comboLanguage->addItem(QString::fromStdString(langName), i + 1);
+    }
+
+    ui.comboLanguage->setCurrentIndex(ndsloc::Language::LANG_EN + 1);
+
+    connect(ui.treeFiles, &QTreeWidget::itemChanged, this, &LocUtils::onTreeItemChanged);
+
+    ui.treeFiles->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(ui.treeFiles, &QTreeWidget::customContextMenuRequested, this, &LocUtils::onTreeContextMenu);
+
+    m_workerThread.start();
+
+    updateUiState();
+}
+
+LocUtils::~LocUtils()
+{
+    m_workerThread.quit();
+    m_workerThread.wait();
+
+    delete m_worker;
+    m_worker = nullptr;
+}
+
+void LocUtils::updateUiState()
+{
+    const bool idle = !m_bIsBusy;
+
+    ui.treeFiles->setEnabled(idle);
+    ui.buttonSelectAll->setEnabled(idle && m_bRomLoaded);
+    ui.buttonSelectNone->setEnabled(idle && m_bRomLoaded && m_selectedCount > 0);
+
+    ui.comboLanguage->setEnabled(idle && m_bRomLoaded);
+    ui.buttonExportStringsToCsv->setEnabled(idle && m_bRomLoaded && m_selectedCount > 0);
+
+    emit busyChanged(m_bIsBusy);
+}
+
+void LocUtils::beginTask()
+{
+    m_bIsBusy = true;
+    updateUiState();
+}
+
+void LocUtils::loadRom(QString romPath)
+{
+    m_bRomLoaded = false;
+    m_selectedCount = 0;
+
+    clearFileTree();
+
+    beginTask();
+    emit requestLoadRom(romPath);
+}
+
+void LocUtils::loadRomData(uint8_t* data, uint32_t size)
+{
+    m_bRomLoaded = false;
+    m_selectedCount = 0;
+
+    clearFileTree();
+
+    beginTask();
+    emit requestLoadRomData(data, size);
+}
+
+void LocUtils::on_buttonExportStringsToCsv_clicked()
+{
+    const QString path = QFileDialog::getExistingDirectory(this, tr("Select target folder"));
+
+    if (path.isEmpty())
+        return;
+
+    const QStringList files = selectedFiles();
+    if (files.isEmpty())
+        return;
+
+    beginTask();
+    emit requestExportStrings(path, files, ndsloc::ExportFormat::Csv, selectedLanguage());
+}
+
+int8_t LocUtils::selectedLanguage() const
+{
+    const QVariant data = ui.comboLanguage->currentData();
+    return data.isValid() ? (data.toInt() - 1) : -1;
+}
+
+void LocUtils::on_buttonSelectAll_clicked()
+{
+    setAllChecked(Qt::Checked);
+}
+
+void LocUtils::on_buttonSelectNone_clicked()
+{
+    setAllChecked(Qt::Unchecked);
+}
+
+void LocUtils::appendLog(const std::string& text)
+{
+    ui.textEditLog->moveCursor(QTextCursor::End);
+    ui.textEditLog->insertPlainText(QString::fromStdString(text));
+    ui.textEditLog->moveCursor(QTextCursor::End);
+}
+
+void LocUtils::appendLogLine(const QString& text)
+{
+    appendLog(text.toStdString() + "\n");
+}
+
+void LocUtils::onRomLoaded(bool success)
+{
+    m_bRomLoaded = success;
+    m_bIsBusy = false;
+
+    if (!success)
+    {
+        clearFileTree();
+        m_selectedCount = 0;
+    }
+
+    updateUiState();
+
+    if (success)
+        appendLog("~~ rom loaded ~~\n");
+    else
+        appendLog("~~ failed to load rom ~~\n");
+}
+
+void LocUtils::onFilesystemListed(const NdsFileEntryList& entries)
+{
+    populateFileTree(entries);
+}
+
+void LocUtils::onTaskFinished(bool success)
+{
+    m_bIsBusy = false;
+    updateUiState();
+
+    if (success)
+        appendLog("~~ finished! ~~\n");
+}
+
+void LocUtils::onExportFinished(const NdsExportResult& result)
+{
+    m_bIsBusy = false;
+    updateUiState();
+
+    if (!result.success)
+    {
+        appendLogLine(QStringLiteral("~~ export failed ~~"));
+        return;
+    }
+
+    if (result.files.isEmpty())
+    {
+        appendLogLine(QStringLiteral("~~ export finished: no strings found ~~"));
+        return;
+    }
+
+    int widest = 0;
+    for (const NdsExportedFile& file : result.files)
+    {
+        widest = qMax(widest, file.path.size());
+    }
+
+    appendLogLine(QStringLiteral("~~ exported %1 file(s), %2 string(s) ~~").arg(result.files.size()).arg(result.totalStrings()));
+
+    for (const NdsExportedFile& file : result.files)
+    {
+        appendLogLine(QStringLiteral("  %1  %2").arg(file.path.leftJustified(widest, ' ')).arg(file.stringCount, 6));
+    }
+}
+
+void LocUtils::clearFileTree()
+{
+    m_updatingTree = true;
+    m_fileItems.clear();
+    ui.treeFiles->clear();
+    m_updatingTree = false;
+}
+
+void LocUtils::populateFileTree(const NdsFileEntryList& entries)
+{
+    m_updatingTree = true;
+    ui.treeFiles->setUpdatesEnabled(false);
+
+    m_fileItems.clear();
+    ui.treeFiles->clear();
+
+    QHash<QString, QTreeWidgetItem*> folders;
+
+    for (const NdsFileEntry& entry : entries)
+    {
+        const QStringList parts = entry.path.split('/', Qt::SkipEmptyParts);
+        if (parts.isEmpty())
+            continue;
+
+        QTreeWidgetItem* parent = nullptr;
+        QString folderPath;
+
+        for (int i = 0; i < parts.size() - 1; ++i)
+        {
+            folderPath += '/' + parts[i];
+
+            auto it = folders.find(folderPath);
+            if (it == folders.end())
+            {
+                auto* folder = parent ? new QTreeWidgetItem(parent)
+                                      : new QTreeWidgetItem(ui.treeFiles);
+                folder->setText(ColumnName, parts[i]);
+                folder->setText(ColumnType, QStringLiteral("Folder"));
+                folder->setFlags(folder->flags() | Qt::ItemIsUserCheckable);
+                folder->setCheckState(ColumnName, Qt::Unchecked);
+                folder->setData(ColumnName, PathRole, folderPath);
+                folder->setData(ColumnName, IsFileRole, false);
+
+                it = folders.insert(folderPath, folder);
+            }
+
+            parent = it.value();
+        }
+
+        const QString& fileName = parts.last();
+
+        auto* file = parent ? new QTreeWidgetItem(parent)
+                            : new QTreeWidgetItem(ui.treeFiles);
+        file->setText(ColumnName, fileName);
+        file->setText(ColumnSize, humanSize(entry.size));
+        file->setTextAlignment(ColumnSize, Qt::AlignRight | Qt::AlignVCenter);
+        file->setText(ColumnType, entry.type);
+        file->setFlags(file->flags() | Qt::ItemIsUserCheckable);
+        file->setCheckState(ColumnName, Qt::Unchecked);
+        file->setData(ColumnName, PathRole, entry.path);
+        file->setData(ColumnName, SizeRole, QVariant::fromValue(entry.size));
+        file->setData(ColumnName, IsFileRole, true);
+
+        m_fileItems.insert(entry.path, file);
+    }
+
+    ui.treeFiles->expandToDepth(0);
+    ui.treeFiles->setUpdatesEnabled(true);
+    m_updatingTree = false;
+
+    m_selectedCount = 0;
+
+    applyDefaultSelection();
+
+    updateSelectionInfo();
+    updateUiState();
+}
+
+void LocUtils::onTreeItemChanged(QTreeWidgetItem* item, int column)
+{
+    if (m_updatingTree || column != ColumnName || item == nullptr)
+        return;
+
+    m_updatingTree = true;
+
+    const Qt::CheckState state = item->checkState(ColumnName);
+    if (item->childCount() > 0 && state != Qt::PartiallyChecked)
+        setCheckStateRecursive(item, state);
+
+    refreshParentCheckState(item->parent());
+
+    m_updatingTree = false;
+
+    updateSelectionInfo();
+    updateUiState();
+}
+
+void LocUtils::setCheckStateRecursive(QTreeWidgetItem* item, Qt::CheckState state)
+{
+    for (int i = 0; i < item->childCount(); ++i)
+    {
+        QTreeWidgetItem* child = item->child(i);
+        child->setCheckState(ColumnName, state);
+        setCheckStateRecursive(child, state);
+    }
+}
+
+void LocUtils::refreshParentCheckState(QTreeWidgetItem* item)
+{
+    while (item != nullptr)
+    {
+        int checked = 0;
+        int partial = 0;
+        const int count = item->childCount();
+
+        for (int i = 0; i < count; ++i)
+        {
+            switch (item->child(i)->checkState(ColumnName))
+            {
+            case Qt::Checked: ++checked; break;
+            case Qt::PartiallyChecked: ++partial; break;
+            default: break;
+            }
+        }
+
+        Qt::CheckState state = Qt::Unchecked;
+        if (partial > 0 || (checked > 0 && checked < count))
+            state = Qt::PartiallyChecked;
+        else if (count > 0 && checked == count)
+            state = Qt::Checked;
+
+        item->setCheckState(ColumnName, state);
+        item = item->parent();
+    }
+}
+
+void LocUtils::recomputeFolderStates(QTreeWidgetItem* item)
+{
+    const int count = item->childCount();
+
+    int checked = 0;
+    int partial = 0;
+
+    for (int i = 0; i < count; ++i)
+    {
+        QTreeWidgetItem* child = item->child(i);
+
+        if (!child->data(ColumnName, IsFileRole).toBool())
+            recomputeFolderStates(child);
+
+        switch (child->checkState(ColumnName))
+        {
+        case Qt::Checked:          ++checked; break;
+        case Qt::PartiallyChecked: ++partial; break;
+        default:                             break;
+        }
+    }
+
+    if (item == ui.treeFiles->invisibleRootItem())
+        return;
+
+    Qt::CheckState state = Qt::Unchecked;
+    if (partial > 0 || (checked > 0 && checked < count))
+        state = Qt::PartiallyChecked;
+    else if (count > 0 && checked == count)
+        state = Qt::Checked;
+
+    item->setCheckState(ColumnName, state);
+}
+
+void LocUtils::setAllChecked(Qt::CheckState state)
+{
+    m_updatingTree = true;
+    ui.treeFiles->setUpdatesEnabled(false);
+
+    setCheckStateRecursive(ui.treeFiles->invisibleRootItem(), state);
+
+    ui.treeFiles->setUpdatesEnabled(true);
+    m_updatingTree = false;
+
+    updateSelectionInfo();
+    updateUiState();
+}
+
+void LocUtils::setItemsChecked(const QList<QTreeWidgetItem*>& items, Qt::CheckState state)
+{
+    if (items.isEmpty())
+        return;
+
+    m_updatingTree = true;
+    ui.treeFiles->setUpdatesEnabled(false);
+
+    for (QTreeWidgetItem* item : items)
+    {
+        item->setCheckState(ColumnName, state);
+        setCheckStateRecursive(item, state);
+    }
+
+    recomputeFolderStates(ui.treeFiles->invisibleRootItem());
+
+    ui.treeFiles->setUpdatesEnabled(true);
+    m_updatingTree = false;
+
+    updateSelectionInfo();
+    updateUiState();
+}
+
+void LocUtils::collectFilePaths(const QTreeWidgetItem* item, QStringList& out) const
+{
+    for (int i = 0; i < item->childCount(); ++i)
+    {
+        const QTreeWidgetItem* child = item->child(i);
+
+        if (child->data(ColumnName, IsFileRole).toBool())
+            out << child->data(ColumnName, PathRole).toString();
+        else
+            collectFilePaths(child, out);
+    }
+}
+
+void LocUtils::collectCheckedFiles(const QTreeWidgetItem* item, QStringList& out) const
+{
+    for (int i = 0; i < item->childCount(); ++i)
+    {
+        const QTreeWidgetItem* child = item->child(i);
+
+        if (child->data(ColumnName, IsFileRole).toBool())
+        {
+            if (child->checkState(ColumnName) == Qt::Checked)
+                out << child->data(ColumnName, PathRole).toString();
+        }
+        else
+        {
+            collectCheckedFiles(child, out);
+        }
+    }
+}
+
+QStringList LocUtils::selectedFiles() const
+{
+    QStringList out;
+    collectCheckedFiles(ui.treeFiles->invisibleRootItem(), out);
+    return out;
+}
+
+void LocUtils::updateSelectionInfo()
+{
+    m_selectedCount = selectedFiles().size();
+
+    ui.statusBar->setText(m_selectedCount == 0
+        ? QStringLiteral("No file selected")
+        : QStringLiteral("%1 file(s) selected").arg(m_selectedCount));
+}
+
+QList<QTreeWidgetItem*> LocUtils::matchPattern(const QString& pattern) const
+{
+    QList<QTreeWidgetItem*> matches;
+
+    const bool isWildcard = pattern.contains('*') || pattern.contains('?');
+    const bool isFullPath = pattern.startsWith('/');
+
+    if (!isWildcard && isFullPath)
+    {
+        const auto it = m_fileItems.find(pattern);
+        if (it != m_fileItems.end())
+            matches << it.value();
+        return matches;
+    }
+
+    QRegularExpression regex;
+    if (isWildcard)
+    {
+        regex = QRegularExpression(
+            QRegularExpression::anchoredPattern(
+                QRegularExpression::wildcardToRegularExpression(pattern)),
+            QRegularExpression::CaseInsensitiveOption);
+    }
+
+    for (auto it = m_fileItems.constBegin(); it != m_fileItems.constEnd(); ++it)
+    {
+        const QString& fullPath = it.key();
+        const QString fileName = fullPath.section('/', -1);
+
+        const bool hit = isWildcard
+            ? (regex.match(fullPath).hasMatch() || regex.match(fileName).hasMatch())
+            : (isFullPath ? fullPath.compare(pattern, Qt::CaseInsensitive) == 0
+                          : fileName.compare(pattern, Qt::CaseInsensitive) == 0);
+
+        if (hit)
+            matches << it.value();
+    }
+
+    return matches;
+}
+
+void LocUtils::expandAncestors(QTreeWidgetItem* item)
+{
+    for (QTreeWidgetItem* parent = item->parent(); parent != nullptr; parent = parent->parent())
+        parent->setExpanded(true);
+}
+
+void LocUtils::applyDefaultSelection()
+{
+    for (auto* item : m_fileItems)
+    {
+        item->setCheckState(ColumnName, Qt::Checked);
+    }
+}
+
+
+void LocUtils::onTreeContextMenu(const QPoint& pos)
+{
+    if (m_bIsBusy)
+        return;
+
+    QTreeWidgetItem* clicked = ui.treeFiles->itemAt(pos);
+
+    QMenu menu(this);
+
+    if (clicked == nullptr)
+    {
+        QAction* expandAll = menu.addAction(tr("Expand all"));
+        connect(expandAll, &QAction::triggered, ui.treeFiles, &QTreeWidget::expandAll);
+
+        QAction* collapseAll = menu.addAction(tr("Collapse all"));
+        connect(collapseAll, &QAction::triggered, ui.treeFiles, &QTreeWidget::collapseAll);
+
+        menu.exec(ui.treeFiles->viewport()->mapToGlobal(pos));
+        return;
+    }
+
+    if (!ui.treeFiles->selectedItems().contains(clicked))
+        ui.treeFiles->setCurrentItem(clicked);
+
+    const TreeContext ctx = buildTreeContext(clicked);
+
+    if (ctx.hasFolders)
+        addFolderActions(menu, ctx);
+
+    if (ctx.hasFiles)
+        addFileActions(menu, ctx);
+
+    addCommonActions(menu, ctx);
+
+    if (!menu.isEmpty())
+    {
+        menu.exec(ui.treeFiles->viewport()->mapToGlobal(pos));
+    }
+}
+
+LocUtils::TreeContext LocUtils::buildTreeContext(QTreeWidgetItem* clicked) const
+{
+    TreeContext ctx;
+    ctx.clicked = clicked;
+
+    QList<QTreeWidgetItem*> selection = ui.treeFiles->selectedItems();
+    if (selection.isEmpty())
+        selection << clicked;
+
+    const QSet<QTreeWidgetItem*> selectionSet(selection.begin(), selection.end());
+
+    for (QTreeWidgetItem* item : selection)
+    {
+        bool coveredByAncestor = false;
+        for (QTreeWidgetItem* p = item->parent(); p != nullptr; p = p->parent())
+        {
+            if (selectionSet.contains(p))
+            {
+                coveredByAncestor = true;
+                break;
+            }
+        }
+
+        if (!coveredByAncestor)
+            ctx.items << item;
+    }
+
+
+    QStringList types;
+
+    for (QTreeWidgetItem* item : ctx.items)
+    {
+        if (item->data(ColumnName, IsFileRole).toBool())
+        {
+            ctx.hasFiles = true;
+            ctx.filePaths << item->data(ColumnName, PathRole).toString();
+
+            types.append(item->text(ColumnType));
+        }
+        else
+        {
+            ctx.hasFolders = true;
+            collectFilePaths(item, ctx.filePaths);
+        }
+    }
+
+    QString commonType = "";
+    bool uniform = !ctx.filePaths.isEmpty();
+    for (auto& type : types)
+    {
+        if (commonType.isEmpty())
+            commonType = type;
+        else if (commonType != type)
+        {
+            uniform = false;
+            break;
+        }
+    }
+
+    if (uniform)
+        ctx.commonType = commonType;
+
+    return ctx;
+}
+
+void LocUtils::addFolderActions(QMenu& menu, const TreeContext& ctx)
+{
+    QAction* expand = menu.addAction(tr("Expand"));
+    connect(expand, &QAction::triggered, this, [ctx]() {
+        for (QTreeWidgetItem* item : ctx.items)
+            setExpandedRecursive(item, true);
+    });
+
+    QAction* collapse = menu.addAction(tr("Collapse"));
+    connect(collapse, &QAction::triggered, this, [ctx]() {
+        for (QTreeWidgetItem* item : ctx.items)
+            setExpandedRecursive(item, false);
+    });
+
+    menu.addSeparator();
+}
+
+void LocUtils::addFileActions(QMenu& menu, const TreeContext& ctx)
+{
+    int fileCount = ctx.filePaths.size();
+    auto getActionName = [&fileCount](const char* name, const char* type) -> QString
+    {
+        return (fileCount > 1)
+            ? tr("%1 %2 %3 files...").arg(name, QString::number(fileCount), type)
+            : tr("%1 %2 file...").arg(name, type);
+    };
+
+    if (ctx.commonType == QLatin1String("p2"))
+    {
+        QAction* extract = menu.addAction(getActionName("Extract and decompress", "P2"));
+        connect(extract, &QAction::triggered, this, [this, ctx]() { actionExtractFile(ctx, EExtractType::P2); });
+    }
+    else if (ctx.commonType == QLatin1String("z"))
+    {
+        QAction* decompress = menu.addAction(getActionName("Decompress", "Z"));
+        connect(decompress, &QAction::triggered, this, [this, ctx]() { actionExtractFile(ctx, EExtractType::Z); });
+    }
+
+    QAction* extractRaw = menu.addAction(getActionName("Extract", "raw"));
+    connect(extractRaw, &QAction::triggered, this, [this, ctx]() { actionExtractFile(ctx, EExtractType::Raw); });
+
+    menu.addSeparator();
+}
+
+void LocUtils::addCommonActions(QMenu& menu, const TreeContext& ctx)
+{
+    QAction* tick = menu.addAction(tr("Tick for export"));
+    tick->setEnabled(!ctx.items.isEmpty());
+    connect(tick, &QAction::triggered, this, [this, ctx]() {
+        setItemsChecked(ctx.items, Qt::Checked);
+    });
+
+    QAction* untick = menu.addAction(tr("Untick"));
+    untick->setEnabled(!ctx.items.isEmpty());
+    connect(untick, &QAction::triggered, this, [this, ctx]() {
+        setItemsChecked(ctx.items, Qt::Unchecked);
+    });
+
+    menu.addSeparator();
+
+    QAction* copyPath = menu.addAction(ctx.items.size() > 1
+        ? tr("Copy %1 paths").arg(ctx.items.size())
+        : tr("Copy path"));
+    connect(copyPath, &QAction::triggered, this, [ctx]() {
+        QStringList paths;
+        for (QTreeWidgetItem* item : ctx.items)
+            paths << item->data(ColumnName, PathRole).toString();
+
+        QGuiApplication::clipboard()->setText(paths.join('\n'));
+    });
+}
+
+void LocUtils::actionExtractFile(const TreeContext& ctx, EExtractType type)
+{
+    if (ctx.filePaths.isEmpty())
+        return;
+
+    const QString outFolder = QFileDialog::getExistingDirectory(
+        this,
+        tr("Extract %1 file(s) to...").arg(ctx.filePaths.size()),
+        m_lastExtractFolder);
+
+    if (outFolder.isEmpty())
+        return;
+
+    if (!QFileInfo(outFolder).isWritable())
+    {
+        QMessageBox::warning(this, tr("Extract"), tr("This folder is not writable:\n%1").arg(outFolder));
+        return;
+    }
+
+    m_lastExtractFolder = outFolder;
+
+    appendLog("Extracting " + std::to_string(ctx.filePaths.size()) + " file(s) to: " + outFolder.toStdString() + "\n");
+
+    switch (type)
+    {
+    case EExtractType::Raw:
+        emit requestExtractRawFiles(outFolder, ctx.filePaths);
+        break;
+    case EExtractType::P2:
+        emit requestExtractP2Files(outFolder, ctx.filePaths);
+        break;
+    case EExtractType::Z:
+        emit requestExtractZFiles(outFolder, ctx.filePaths);
+        break;
+    default:
+        assert(false);
+    }
+}

--- a/src/frontend/qt_sdl/localization/LocUtils.h
+++ b/src/frontend/qt_sdl/localization/LocUtils.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <QtWidgets/QWidget>
+#include <QStringList>
+#include <QThread>
+
+#include "ui_LocUtils.h"
+
+#include "FileEntry.h"
+#include "ExportResult.h"
+
+#include <string>
+
+class QTreeWidgetItem;
+class Worker;
+
+class LocUtils : public QWidget
+{
+    Q_OBJECT
+
+public:
+    LocUtils(QWidget* parent = nullptr);
+    ~LocUtils();
+
+    void loadRom(QString romPath);
+    void loadRomData(uint8_t* data, uint32_t size);
+
+    bool isBusy() const { return m_bIsBusy; }
+signals:
+    void busyChanged(bool busy);
+    void requestLoadRom(const QString& romPath);
+    void requestLoadRomData(uint8_t* data, uint32_t size);
+    void requestExtractP2Files(const QString& outFolder, const QStringList& files);
+    void requestExtractZFiles(const QString& outFolder, const QStringList& files);
+    void requestExtractRawFiles(const QString& outFolder, const QStringList& files);
+    void requestExportStrings(const QString& outFolder, const QStringList& files, uint8_t format, uint8_t language);
+
+private slots:
+    void on_buttonExportStringsToCsv_clicked();
+    void on_buttonSelectAll_clicked();
+    void on_buttonSelectNone_clicked();
+
+private:
+    struct TreeContext
+    {
+        QTreeWidgetItem* clicked = nullptr;
+        QList<QTreeWidgetItem*> items;
+        QStringList filePaths;
+
+        bool hasFiles = false;
+        bool hasFolders = false;
+        QString commonType;
+    };
+
+    void appendLog(const std::string& text);
+    void appendLogLine(const QString& text);
+    void onRomLoaded(bool success);
+    void onFilesystemListed(const NdsFileEntryList& entries);
+    void onTaskFinished(bool success);
+    void onExportFinished(const NdsExportResult& result);
+
+    void clearFileTree();
+    void populateFileTree(const NdsFileEntryList& entries);
+    void onTreeItemChanged(QTreeWidgetItem* item, int column);
+    void setCheckStateRecursive(QTreeWidgetItem* item, Qt::CheckState state);
+    void refreshParentCheckState(QTreeWidgetItem* item);
+    void recomputeFolderStates(QTreeWidgetItem* item);
+    void setAllChecked(Qt::CheckState state);
+    void setItemsChecked(const QList<QTreeWidgetItem*>& items, Qt::CheckState state);
+    void collectCheckedFiles(const QTreeWidgetItem* item, QStringList& out) const;
+    void collectFilePaths(const QTreeWidgetItem* item, QStringList& out) const;
+    QStringList selectedFiles() const;
+    void updateSelectionInfo();
+
+    void applyDefaultSelection();
+    QList<QTreeWidgetItem*> matchPattern(const QString& pattern) const;
+    void expandAncestors(QTreeWidgetItem* item);
+
+    void onTreeContextMenu(const QPoint& pos);
+    TreeContext buildTreeContext(QTreeWidgetItem* clicked) const;
+    void addFolderActions(QMenu& menu, const TreeContext& ctx);
+    void addFileActions(QMenu& menu, const TreeContext& ctx);
+    void addCommonActions(QMenu& menu, const TreeContext& ctx);
+
+    enum EExtractType : uint8_t { Raw = 0, P2, Z };
+    void actionExtractFile(const TreeContext& ctx, EExtractType type);
+
+    int8_t selectedLanguage() const;
+
+    void setBusy(bool busy);
+    void beginTask();
+    void updateUiState();
+
+    Ui::LocUtilsClass ui;
+
+    QThread m_workerThread;
+    Worker* m_worker = nullptr;
+
+    bool m_bIsBusy = false;
+    bool m_bRomLoaded = false;
+    bool m_updatingTree = false;
+    int m_selectedCount = 0;
+
+    QString m_lastExtractFolder;
+    QHash<QString, QTreeWidgetItem*> m_fileItems;
+};

--- a/src/frontend/qt_sdl/localization/LocUtils.qrc
+++ b/src/frontend/qt_sdl/localization/LocUtils.qrc
@@ -1,0 +1,4 @@
+<RCC>
+    <qresource prefix="LocUtilsUI">
+    </qresource>
+</RCC>

--- a/src/frontend/qt_sdl/localization/LocUtils.ui
+++ b/src/frontend/qt_sdl/localization/LocUtils.ui
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LocUtilsClass</class>
+ <widget class="QWidget" name="QtNDSLocUtilsClass">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1000</width>
+    <height>560</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>760</width>
+    <height>400</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>NDS Loc Utils</string>
+  </property>
+  <layout class="QVBoxLayout" name="layoutMain">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QSplitter" name="splitterMain">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="panelFiles" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>2</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <layout class="QVBoxLayout" name="layoutFiles">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTreeWidget" name="treeFiles">
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
+         </property>
+         <column>
+          <property name="text">
+           <string>Name</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Size</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Type</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="layoutTreeButtons">
+         <item>
+          <widget class="QPushButton" name="buttonSelectAll">
+           <property name="text">
+            <string>Select all</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonSelectNone">
+           <property name="text">
+            <string>Select none</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="statusBar"/>
+         </item>
+         <item>
+          <spacer name="spacerTreeButtons">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="panelRight" native="true">
+      <layout class="QVBoxLayout" name="layoutRight">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="layoutActions">
+         <item>
+          <spacer name="spacerActions">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelLanguage">
+           <property name="text">
+            <string>Lang:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboLanguage">
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>32</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonExportStringsToCsv">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Export strings to CSV</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QTextEdit" name="textEditLog">
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/frontend/qt_sdl/localization/Worker.cpp
+++ b/src/frontend/qt_sdl/localization/Worker.cpp
@@ -1,0 +1,323 @@
+#include "Worker.h"
+
+#include "LocUtils.h"
+
+#include "localization/nds.h"
+#include "localization/lang.h"
+#include "localization/utils.h"
+#include "localization/p2.h"
+#include "localization/strings.h"
+#include "localization/stringtable.h"
+#include "localization/lzss.h"
+
+#include <QFileInfo>
+#include <QDir>
+
+#include <fstream>
+
+Worker::Worker(QObject* parent)
+    : QObject(parent)
+{
+}
+
+Worker::~Worker()
+{
+}
+
+void Worker::clearRom()
+{
+    m_fs.reset();
+    m_romBuffer.clear();
+    m_romData = nullptr;
+    m_romDataSize = 0;
+}
+
+void Worker::loadRom(const QString& romPath)
+{
+    const std::string path = romPath.toStdString();
+
+    emit log("Reading file: " + path + "\n");
+
+    auto romData = utils::readBinaryFile(path);
+    if (romData.empty())
+    {
+        clearRom();
+        emit log("Failed to read file\n");
+        emit romLoaded(false);
+        return;
+    }
+
+    m_romBuffer = std::move(romData);
+
+    loadRomData(m_romBuffer.data(), m_romBuffer.size());
+}
+
+void Worker::loadRomData(uint8_t* data, uint32_t size)
+{
+    clearRom();
+
+    m_romData = data;
+    m_romDataSize = size;
+
+    emit log("Parsing filesystem...\n");
+    m_fs = std::make_unique<NDS::NDSFileSystem>(data, size);
+    m_fs->getRomFileSystem(true);
+
+    const NdsFileEntryList entries = buildEntryList();
+
+    emit log("Loaded " + std::to_string(size) + " bytes, " + std::to_string(entries.size()) + " files.\n");
+
+    emit filesystemListed(entries);
+    emit romLoaded(true);
+}
+
+NdsFileEntryList Worker::buildEntryList() const
+{
+    NdsFileEntryList list;
+    if (!m_fs)
+        return list;
+
+    const auto& entries = m_fs->getAllEntries();
+    list.reserve(static_cast<int>(entries.size()));
+
+    for (const auto& entry : entries)
+    {
+        NdsFileEntry e;
+        e.path = QString::fromStdString(entry.filename);
+        e.type = QString::fromStdString(entry.type);
+        e.size = static_cast<quint64>(entry.size);
+
+        list.push_back(e);
+    }
+
+    return list;
+}
+
+void Worker::printFilesystem()
+{
+    if (!m_fs)
+    {
+        emit log("No ROM loaded.\n");
+        emit taskFinished(false);
+        return;
+    }
+
+    std::string strings;
+    for (const auto& entry : m_fs->getAllEntries())
+    {
+        strings += "  File: " + entry.filename + "\n";
+    }
+
+    emit log(strings);
+    emit taskFinished(true);
+}
+
+void Worker::extractP2Files(const QString& outFolder, const QStringList& files)
+{
+    assert(m_romData && m_romDataSize > 0);
+
+    for (const QString& file : files)
+    {
+        if (auto* entry = m_fs->findEntryByName(file.toStdString()))
+        {
+            auto* data = m_romData + entry->start;
+
+            if (entry->type == "p2")
+            {
+                auto p2file = ndsloc::P2File(data, entry->size);
+
+                auto& subfiles = p2file.readAndGetFileTable();
+                for (auto& subfile : subfiles)
+                {
+                    auto outPath = QDir(outFolder).filePath(QString::fromStdString(subfile.getFilename()));
+
+                    if (subfile.isCompressed())
+                    {
+                        ndsloc::LZSSFile file(subfile.inputPtr, subfile.fileSize);
+                        file.decompress();
+                        file.saveToDisk(outPath.toStdString());
+                    }
+                    else
+                    {
+                        std::ofstream os(outPath.toStdString(), std::ofstream::binary);
+                        os.write((char*)subfile.inputPtr, subfile.fileSize);
+                    }
+                }
+            }
+            else
+            {
+                assert(false);
+            }
+        }
+    }
+
+    emit taskFinished(true);
+}
+
+void Worker::extractZFiles(const QString& outFolder, const QStringList& files)
+{
+    assert(m_romData);
+
+    for (const QString& file : files)
+    {
+        if (auto* entry = m_fs->findEntryByName(file.toStdString()))
+        {
+            auto fileInfo = QFileInfo(file);
+            auto outPath = QDir(outFolder).filePath(fileInfo.fileName());
+
+            auto suffix = fileInfo.suffix().toLower();
+            if (suffix == "z")
+            {
+                auto* data = m_romData + entry->start;
+                ndsloc::LZSSFile file(data, entry->size);
+                file.decompress();
+                file.saveToDisk(outPath.toStdString());
+            }
+            else
+            {
+                assert(false);
+            }
+        }
+    }
+}
+
+void Worker::extractRawFiles(const QString& outFolder, const QStringList& files)
+{
+    assert(m_romData);
+
+    for (const QString& file : files)
+    {
+        if (auto* entry = m_fs->findEntryByName(file.toStdString()))
+        {
+            auto outPath = QDir(outFolder).filePath(QFileInfo(file).fileName());
+
+            std::ofstream os(outPath.toStdString(), std::ofstream::binary);
+
+            auto* data = m_romData + entry->start;
+            os.write((char*)data, entry->size);
+        }
+    }
+}
+
+void Worker::exportStrings(const QString& outFolder, const QStringList& files, uint8_t fmt, uint8_t language)
+{
+    assert(m_romData);
+
+    using namespace ndsloc;
+
+    if (!m_fs)
+    {
+        emit log("No ROM loaded.\n");
+        emit taskFinished(false);
+        return;
+    }
+
+    if (files.isEmpty())
+    {
+        emit log("No files selected.\n");
+        emit taskFinished(false);
+        return;
+    }
+
+    emit log("Exporting strings to: " + outFolder.toStdString() + "\n");
+
+    auto format = (ndsloc::ExportFormat)fmt;
+
+    std::map<uint8_t, std::ofstream> streams;
+
+    auto filePathFromLang = [&](auto lng)
+    {
+        auto filename = getLanguageFileName(static_cast<Language>(lng));
+        return QDir(outFolder).filePath(QString::fromStdString(filename));
+    };
+
+    if (language == -1)
+    {
+        for (int i = 0; i < Language::LANG_COUNT; i++)
+        {
+            auto outPathNoExt = filePathFromLang(i);
+            streams[i] = std::move(strings::startFile(outPathNoExt.toStdString(), format));
+        }
+    }
+    else
+    {
+        auto outPathNoExt = filePathFromLang(language);
+        streams[language] = std::move(strings::startFile(outPathNoExt.toStdString(), format));
+    }
+
+    NdsExportResult result;
+
+    for (const QString& file : files)
+    {
+        const std::string filePath = file.toStdString();
+
+        auto* entry = m_fs->findEntryByName(filePath);
+        if (entry)
+        {
+            auto* data = m_romData + entry->start;
+            auto fileInfo = QFileInfo(QString::fromStdString(filePath));
+            auto fileName = fileInfo.baseName();
+
+            auto filenameInCsv = entry->filename; // fileName.toStdString();
+
+            if (entry->type == "p2")
+            {
+                P2File p2(data, entry->size);
+
+                for (auto& os : streams)
+                {
+                    auto lang = static_cast<Language>(os.first);
+                    if (shouldIgnoreFile(entry->filename, lang))
+                        continue;
+
+                    std::vector<String> out_strings;
+                    p2.setLanguage(lang);
+                    p2.extractStrings(out_strings);
+                    strings::writeStrings(format, os.second, entry->start, filenameInCsv, out_strings);
+
+                    if (!out_strings.empty())
+                    {
+                        NdsExportedFile f;
+                        f.path = file;
+                        f.stringCount = out_strings.size();
+                        result.files.append(std::move(f));
+                    }
+                }
+            }
+            else if (entry->type == "z")
+            {
+                LZSSFile lzss(data, entry->size);
+                lzss.decompress();
+
+                for (auto& os : streams)
+                {
+                    auto lang = static_cast<Language>(os.first);
+                    if (shouldIgnoreFile(entry->filename, lang))
+                        continue;
+
+                    uint32_t count = StringTableFile::exportStrings(os.second, lzss.getConvertedData(), format, filenameInCsv, fileInfo.suffix().toStdString(), entry->start);
+
+                    if (count > 0)
+                    {
+                        NdsExportedFile f;
+                        f.path = file;
+                        f.stringCount = count;
+                        result.files.append(std::move(f));
+                    }
+                }
+            }
+            else
+            {
+                // Not implemented
+            }
+        }
+    }
+
+    result.success = true;
+    emit exportFinished(result);
+}
+
+void Worker::logCallback(const std::string& str)
+{
+    emit log(str);
+}

--- a/src/frontend/qt_sdl/localization/Worker.h
+++ b/src/frontend/qt_sdl/localization/Worker.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <QObject>
+
+#include "FileEntry.h"
+#include "ExportResult.h"
+
+namespace NDS {
+class NDSFileSystem;
+}
+
+class Worker : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit Worker(QObject* parent = nullptr);
+    ~Worker() override;
+
+public slots:
+    void loadRom(const QString& romPath);
+    void loadRomData(uint8_t* data, uint32_t size);
+    void printFilesystem();
+    void extractP2Files(const QString& outFolder, const QStringList& files);
+    void extractZFiles(const QString& outFolder, const QStringList& files);
+    void exportStrings(const QString& outFolder, const QStringList& files, uint8_t format, uint8_t language);
+    void extractRawFiles(const QString& outFolder, const QStringList& files);
+
+signals:
+    void log(const std::string& str);
+    void romLoaded(bool success);
+    void filesystemListed(const NdsFileEntryList& entries);
+    void exportFinished(const NdsExportResult& result);
+    void taskFinished(bool success);
+
+private:
+    void logCallback(const std::string& str);
+
+    void clearRom();
+    NdsFileEntryList buildEntryList() const;
+
+    std::unique_ptr<NDS::NDSFileSystem> m_fs;
+
+    std::vector<uint8_t> m_romBuffer;
+    uint8_t* m_romData = nullptr;
+    uint32_t m_romDataSize = 0;
+};

--- a/src/plugins/PluginKingdomHeartsDays.cpp
+++ b/src/plugins/PluginKingdomHeartsDays.cpp
@@ -1,5 +1,7 @@
 #include "PluginKingdomHeartsDays.h"
 #include "KingdomHeartsHDCollection.h"
+#include "localization/strings.h"
+#include "localization/rompatcher.h"
 #include <cmath>
 
 namespace Plugins
@@ -606,115 +608,19 @@ bool PluginKingdomHeartsDays::shouldOpenKHExtendedSettings() {
 }
 
 void PluginKingdomHeartsDays::loadLocalization() {
-    u8* rom = (u8*)nds->GetNDSCart()->GetROM();
-
-    std::string language = GameLanguage.code;
+    std::string language = "en-US"; //GameLanguage.code;
 
     std::string LocalizationFilePath = localizationFilePath(language);
-    Platform::FileHandle* f = Platform::OpenLocalFile(LocalizationFilePath.c_str(), Platform::FileMode::ReadText);
-    if (f) {
-        char linebuf[1024];
-        char entryname[32];
-        char entryval[1024];
-        bool firstLine = true;
-        while (!Platform::IsEndOfFile(f))
-        {
-            if (!Platform::FileReadLine(linebuf, 1024, f))
-                break;
+    if (LocalizationFilePath.empty())
+        return;
 
-            const char* line = linebuf;
-            if (firstLine)
-            {
-                firstLine = false;
-                line = skipUtf8Bom(line);
-            }
+    NDSCart::CartCommon* cart = nds->GetNDSCart();
+    u8* rom = (u8*)cart->GetROM();
+    u32 romLength = cart->GetROMLength();
 
-            int ret = sscanf(line, "%31[A-Za-z_0-9]=%[^\t\r\n]", entryname, entryval);
-            entryname[31] = '\0';
-            if (ret < 2) continue;
-
-            std::string entrynameStr = std::string(entryname);
-            if (entrynameStr.compare(0, 2, "0x") == 0) {
-                int addrGap = 0;
-                unsigned int addr = std::stoul(entrynameStr.substr(2), nullptr, 16);
-
-                bool ended = false;
-                for (int i = 0; i < 1023; i++) {
-                    if (*((u8*)&rom[addr + i]) == 0x00) {
-                        break;
-                    }
-
-                    if (entryval[i + addrGap] == '\\' && entryval[i + addrGap + 1] == 'n') {
-                        *((u8*)&rom[addr + i]) = 0x0A;
-                        addrGap++;
-                        continue;
-                    }
-
-                    if (entryval[i + addrGap] == 0 || entryval[i + addrGap] == '\0') {
-                        ended = true;
-                    }
-
-                    if (ended) {
-                        *((u8*)&rom[addr + i]) = 0x20;
-                    }
-                    else {
-                        *((u8*)&rom[addr + i]) = entryval[i + addrGap];
-                    }
-                }
-            }
-        }
-
-        CloseFile(f);
-    }
-    else if (false) { // Method that exports the strings from the game ROM
-        int firstAddr = 0;
-        int lastAddr = 0;
-        bool validCharFound = false;
-        bool forbCharFound = false;
-        for (int addr = 0x0689D330; addr < 0x06C49D0C; addr++) {
-            bool usual = rom[addr] >= 0x41 && rom[addr] <= 0x7E;
-            bool accents = rom[addr] == 0xC2 || rom[addr] == 0xC3 || (rom[addr] >= 0x80 && rom[addr] <= 0xBF);
-            bool quotes = rom[addr] == 0xE2 || rom[addr] == 0x80 || rom[addr] == 0x9C || rom[addr] == 0x9D;
-            bool unusual = (rom[addr] >= 0x20 && rom[addr] <= 0x40) || accents || quotes || rom[addr] == 0x0A;
-            bool forb = rom[addr] == 0x93 || rom[addr] == 0x5F || rom[addr] == 0x2F;
-            if (usual || unusual) {
-                if (firstAddr == 0) {
-                    firstAddr = addr;
-                    lastAddr = addr;
-                }
-                else {
-                    lastAddr = addr;
-                }
-            }
-            if (usual) {
-                validCharFound = true;
-            }
-            if (forb) {
-                forbCharFound = true;
-            }
-            if (!usual && !unusual) {
-                if (firstAddr != 0) {
-                    if (!forbCharFound && validCharFound && lastAddr - firstAddr > 2) {
-                        printf("0x%08X=", firstAddr);
-                        for (int pAddr = firstAddr; pAddr <= lastAddr; pAddr++) {
-                            if ((char)rom[pAddr] == 0x0A) {
-                                printf("\\n");
-                            }
-                            else {
-                                printf("%c", (char)rom[pAddr]);
-                            }
-                        }
-                        printf("\n");
-                    }
-
-                    firstAddr = 0;
-                    lastAddr = 0;
-                    validCharFound = false;
-                    forbCharFound = false;
-                }
-            }
-        }
-    }
+    auto modLines = ndsloc::strings::readCsvFile(LocalizationFilePath);
+    uint32_t updatedLinesCount = ndsloc::patcher::createPatch(rom, romLength, modLines);
+    bool bStep = true;
 }
 
 void PluginKingdomHeartsDays::onLoadROM() {
@@ -3352,7 +3258,7 @@ void PluginKingdomHeartsDays::refreshMouseStatus() {
 }
 
 std::string PluginKingdomHeartsDays::localizationFilePath(std::string language) {
-    std::string filename = language + ".ini";
+    std::string filename = language + ".csv";
     std::string assetsRegionSubfolderName = assetsRegionSubfolder();
     std::filesystem::path _assetsFolderPath = gameAssetsFolderPath();
     std::filesystem::path fullPath = _assetsFolderPath / "localization" / assetsRegionSubfolderName / filename;

--- a/src/plugins/localization/cakp.cpp
+++ b/src/plugins/localization/cakp.cpp
@@ -1,0 +1,295 @@
+#include "cakp.h"
+
+#include "utils.h"
+#include "types.h"
+#include "lang.h"
+
+#include <algorithm>
+#include <cstring>
+#include <assert.h>
+
+namespace ndsloc {
+
+namespace cakp {
+
+bool isCAKP(const uint8_t* buffer)
+{
+    return (std::memcmp(buffer, "CAKP", 4) == 0);
+}
+
+bool isTextOpcode(uint8_t group, uint8_t opcode)
+{
+    return group == 0x03 && opcode == 0x01;  // show_subtitle
+}
+
+} // namespace cakp
+
+CAKPFile::CAKPFile(const uint8_t* inputPtr, uint32_t inputSize, std::string sectionName)
+    : m_buffer(inputPtr)
+    , m_bufferSize(inputSize)
+    , m_language(LANG_EN)
+    , m_sectionName(std::move(sectionName))
+{
+}
+
+bool CAKPFile::inRange(uint32_t offset, uint32_t length) const
+{
+    return offset <= m_bufferSize && length <= m_bufferSize - offset;
+}
+
+bool CAKPFile::readDirectory(uint32_t offset, Directory& dir)
+{
+    if (offset == kUnused)
+        return false;
+
+    dir.count = utils::readUInt32(m_buffer, offset);
+
+    if (dir.count > m_bufferSize / 8)
+    {
+        assert(false);
+        return false;
+    }
+
+    dir.offsetsAt = offset + 4;
+    dir.sizesAt = offset + 4 + dir.count * 4;
+
+    return inRange(dir.offsetsAt, dir.count * 8);
+}
+
+bool CAKPFile::directoryEntry(const Directory& dir, uint32_t index, uint32_t& offset, uint32_t& size)
+{
+    if (index >= dir.count)
+        return false;
+
+    offset = utils::readUInt32(m_buffer, dir.offsetsAt + index * 4);
+    size = utils::readUInt32(m_buffer, dir.sizesAt + index * 4);
+
+    return true;
+}
+
+void CAKPFile::addString(uint32_t offset, uint32_t limit, bool allowDuplicates, std::vector<String>& out)
+{
+    if (offset >= limit || limit > m_bufferSize) {
+        return;
+    }
+    if (!allowDuplicates && std::find(m_seen.begin(), m_seen.end(), offset) != m_seen.end()) {
+        return;
+    }
+
+    const uint8_t* const begin = m_buffer + offset;
+    const uint8_t* const end = m_buffer + limit;
+    const uint8_t* p = begin;
+    while (p < end && *p != 0) {
+        ++p;
+    }
+    if (p == end) {
+        return;
+    }
+
+    m_seen.push_back(offset);
+
+    std::string text(reinterpret_cast<const char*>(begin), static_cast<size_t>(p - begin));
+    out.emplace_back(offset, std::move(text), std::string(m_sectionName), false);
+}
+
+void CAKPFile::collectMessageRecord(uint32_t recordAt, uint32_t poolAt, uint32_t sectionEnd, std::vector<String>& out)
+{
+    if (!inRange(recordAt, kMessageSlots * 4) || recordAt + kMessageSlots * 4 > sectionEnd)
+        return;
+
+    for (uint32_t slot = 0; slot < kLanguageCount; ++slot)
+    {
+        if (slot == m_language)
+        {
+            uint32_t textRel = utils::readUInt32(m_buffer, recordAt + slot * 4);
+
+            if (textRel == kUnused) // 0xFFFFFFFF means "no text"
+                continue;
+
+            addString(poolAt + textRel, sectionEnd, false, out);
+        }
+    }
+}
+
+bool CAKPFile::readLanguageCondition(uint32_t conditionAt, uint32_t sectionEnd, uint16_t& language) const
+{
+    if (!inRange(conditionAt, kConditionSize) || conditionAt + kConditionSize > sectionEnd)
+        return false;
+
+    if (utils::readUInt16(m_buffer, conditionAt + kConditionVarIdAt) != kLanguageVarId)
+        return false;
+
+    language = utils::readUInt16(m_buffer, conditionAt + kConditionValueAt);
+    return true;
+}
+
+bool CAKPFile::collectSection(uint32_t sectionAt, uint32_t sectionSize, std::vector<String>& out)
+{
+    if (!inRange(sectionAt, sectionSize) || sectionSize < 8)
+        return false;
+
+    const uint32_t sectionEnd = sectionAt + sectionSize;
+
+    uint32_t poolRel = utils::readUInt32(m_buffer, sectionAt);
+
+    if (poolRel < 4 || poolRel > sectionSize)
+        return false;
+
+    const uint32_t poolAt = sectionAt + poolRel;
+
+    const bool sectionLanguageMatches = (m_sectionLanguage >= 0) && (m_sectionLanguage == static_cast<int>(m_language));
+    uint32_t languageBlockEnd = 0;
+    bool inWantedLanguageBlock = sectionLanguageMatches;
+
+    uint32_t ip = sectionAt + 4;
+    while (ip + sizeof(cakp::Instruction) <= poolAt)
+    {
+        const cakp::Instruction* instr = reinterpret_cast<const cakp::Instruction*>(m_buffer + ip);
+
+        if (instr->sizeInDwords == 0)
+            return false;
+
+        const uint32_t next = ip + static_cast<uint32_t>(instr->sizeInDwords) * 4;
+        if (next > poolAt)
+            return false;
+
+        if (languageBlockEnd != 0 && ip - sectionAt >= languageBlockEnd)
+        {
+            languageBlockEnd = 0;
+            inWantedLanguageBlock = sectionLanguageMatches;
+        }
+
+        const uint32_t argCount = instr->sizeInDwords - 1;
+
+        const bool typedArgs = !(instr->group == 0x00 && instr->opcode == 0x05);
+        if (typedArgs)
+        {
+            for (uint32_t i = 0; i + 1 < argCount; i += 2)
+            {
+                uint32_t type = utils::readUInt32(m_buffer, ip + 4 + i * 4);
+                uint32_t value = utils::readUInt32(m_buffer, ip + 8 + i * 4);
+
+                if (type == cakp::ARG_STR)
+                {
+                    if (inWantedLanguageBlock && cakp::isTextOpcode(instr->group, instr->opcode))
+                        addString(poolAt + value, sectionEnd, false, out);
+                }
+                else if (type == cakp::ARG_MSG)
+                {
+                    collectMessageRecord(poolAt + value, poolAt, sectionEnd, out);
+                }
+            }
+        }
+        else if (argCount >= 2)
+        {
+            const uint32_t conditionAt = poolAt + utils::readUInt32(m_buffer, ip + 4);
+            const uint32_t skipTarget = utils::readUInt32(m_buffer, ip + 8);
+
+            uint16_t conditionLanguage = 0;
+            if (readLanguageCondition(conditionAt, sectionEnd, conditionLanguage))
+            {
+                languageBlockEnd = skipTarget;
+                inWantedLanguageBlock = (conditionLanguage == m_language);
+            }
+        }
+
+        ip = next;
+    }
+    return true;
+}
+
+bool CAKPFile::extractStrings(std::vector<String>& out)
+{
+    out.clear();
+    m_seen.clear();
+
+    assert(cakp::isCAKP(m_buffer));
+
+    const cakp::FileHeader* header = reinterpret_cast<const cakp::FileHeader*>(m_buffer);
+
+    Directory nameDir;
+    Directory sectionDir;
+    if (!readDirectory(header->fileSlots[0], nameDir) ||
+        !readDirectory(header->fileSlots[1], sectionDir))
+        return false;
+
+    std::vector<std::string> sectionNames;
+    readSectionNames(nameDir, sectionNames);
+
+    bool ok = true;
+    for (uint32_t i = 0; i < sectionDir.count; ++i) {
+        uint32_t sectionAt = 0;
+        uint32_t sectionSize = 0;
+        if (!directoryEntry(sectionDir, i, sectionAt, sectionSize))
+        {
+            ok = false;
+            break;
+        }
+
+        m_sectionLanguage = -1;
+        if (i < sectionNames.size())
+        {
+            Language sectionLanguage = LANG_JP;
+            if (languageFromSectionName(sectionNames[i], sectionLanguage))
+                m_sectionLanguage = static_cast<int>(sectionLanguage);
+        }
+
+        if (!collectSection(sectionAt, sectionSize, out)) {
+            ok = false;
+        }
+    }
+
+    m_sectionLanguage = -1;
+
+    std::sort(out.begin(), out.end(), [](const String& a, const String& b) { return a.offset < b.offset; });
+    return ok;
+}
+
+bool CAKPFile::readSectionNames(const Directory& nameDir, std::vector<std::string>& out)
+{
+    out.clear();
+
+    uint32_t nameTableAt = 0;
+    uint32_t nameTableSize = 0;
+    if (!directoryEntry(nameDir, 0, nameTableAt, nameTableSize) || !inRange(nameTableAt, nameTableSize) || nameTableSize < 2)
+        return false;
+
+    const uint16_t nameCount = utils::readUInt16(m_buffer, nameTableAt);
+    const uint32_t nameTableEnd = nameTableAt + nameTableSize;
+
+    if (2 + static_cast<uint32_t>(nameCount) * 2 > nameTableSize)
+        return false;
+
+    out.reserve(nameCount);
+
+    for (uint16_t i = 0; i < nameCount; ++i)
+    {
+        const uint16_t rel = utils::readUInt16(m_buffer, nameTableAt + 2 + i * 2);
+        const uint32_t at = nameTableAt + rel;
+
+        if (at >= nameTableEnd)
+        {
+            out.emplace_back();
+            continue;
+        }
+
+        const uint8_t* const begin = m_buffer + at;
+        const uint8_t* p = begin;
+        while (p < m_buffer + nameTableEnd && *p != 0)
+            ++p;
+
+        out.emplace_back(reinterpret_cast<const char*>(begin), static_cast<size_t>(p - begin));
+    }
+
+    return true;
+}
+
+bool CAKPFile::extractSectionStrings(std::vector<String>& out)
+{
+    out.clear();
+    m_seen.clear();
+    m_sectionLanguage = -1;
+    return collectSection(0, m_bufferSize, out);
+}
+
+} // namespace ndsloc

--- a/src/plugins/localization/cakp.h
+++ b/src/plugins/localization/cakp.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <stdint.h>
+#include <vector>
+#include <string>
+
+namespace ndsloc {
+
+enum Language : uint8_t;
+struct String;
+
+namespace cakp {
+
+#pragma pack(push, 1)
+struct FileHeader
+{
+    char magic[4]; // "CAKP"
+    uint32_t unknown04;
+    uint32_t fileSlots[8];
+};
+
+struct Instruction
+{
+    uint8_t group;
+    uint8_t opcode;
+    uint8_t sizeInDwords; 
+    uint8_t flags;
+};
+
+enum ArgType : uint8_t
+{
+    ARG_NULL = 0x00,
+    ARG_INT = 0x01,
+    ARG_STR = 0x02,
+    ARG_VAR = 0x04,
+    ARG_BYTE = 0x08,
+    ARG_FIXED = 0x10,
+    ARG_MSG = 0x40
+};
+#pragma pack(pop)
+
+bool isCAKP(const uint8_t* buffer);
+
+bool isTextOpcode(uint8_t group, uint8_t opcode);
+
+} // namespace cakp
+
+class CAKPFile
+{
+public:
+    CAKPFile(const uint8_t* inputPtr, uint32_t inputSize, std::string sectionName);
+
+    void setLanguage(Language language) { m_language = language; }
+
+    // Extraction method 1: whole CAKP file
+    bool extractStrings(std::vector<String>& out);
+    // Extraction method 2: single bare section (without CAKP header)
+    bool extractSectionStrings(std::vector<String>& out);
+
+private:
+    struct Directory
+    {
+        uint32_t count;
+        uint32_t offsetsAt;
+        uint32_t sizesAt;
+    };
+
+    bool inRange(uint32_t offset, uint32_t length) const;
+    bool readDirectory(uint32_t offset, Directory& dir);
+    bool directoryEntry(const Directory& dir, uint32_t index, uint32_t& offset, uint32_t& size);
+
+    bool readSectionNames(const Directory& nameDir, std::vector<std::string>& out);
+
+    bool collectSection(uint32_t sectionAt, uint32_t sectionSize, std::vector<String>& out);
+    void collectMessageRecord(uint32_t recordAt, uint32_t poolAt, uint32_t sectionEnd, std::vector<String>& out);
+
+    void addString(uint32_t offset, uint32_t limit, bool allowDuplicates, std::vector<String>& out);
+
+    bool readLanguageCondition(uint32_t conditionAt, uint32_t sectionEnd, uint16_t& language) const;
+
+    const uint8_t* m_buffer = nullptr;
+    uint32_t m_bufferSize = 0;
+    Language m_language;
+
+    int m_sectionLanguage = -1;
+
+    const std::string m_sectionName;
+
+    std::vector<uint32_t> m_seen;
+
+    static constexpr uint16_t kLanguageVarId = 0x2011;
+    static constexpr uint32_t kConditionSize = 24;
+    static constexpr uint32_t kConditionVarIdAt = 0x06;
+    static constexpr uint32_t kConditionValueAt = 0x10;
+
+    static constexpr uint32_t kUnused = 0xFFFFFFFFu;
+    static constexpr uint32_t kMessageSlots = 7;
+    static constexpr uint32_t kLanguageCount = 6;
+};
+
+} // namespace ndsloc

--- a/src/plugins/localization/lang.cpp
+++ b/src/plugins/localization/lang.cpp
@@ -1,0 +1,100 @@
+#include "lang.h"
+
+#include "utils.h"
+
+#include <map>
+
+namespace ndsloc {
+
+std::string getLanguageFileName(Language language)
+{
+    static const std::string strings[] =
+    {
+        "jp-JP",
+        "en-US",
+        "fr-FR",
+        "de-DE",
+        "it-IT",
+        "es-ES"
+    };
+
+    return strings[language];
+}
+
+std::string getLanguageName(Language language)
+{
+    static const std::string strings[] =
+    {
+        "JP",
+        "EN",
+        "FR",
+        "DE",
+        "IT",
+        "ES"
+    };
+
+    return strings[language];
+}
+
+bool shouldIgnoreFile(const std::string& filename, Language language)
+{
+    std::string str = filename;
+
+    auto idx = filename.find_first_of('.');
+    if (idx != std::string::npos)
+    {
+        str = filename.substr(0, idx);
+    }
+
+    if ((utils::ends_with(str,"_en") || str.find("/en/") != std::string::npos) && language != Language::LANG_EN)
+        return true;
+    else if ((utils::ends_with(str,"_fr") || str.find("/fr/") != std::string::npos) && language != Language::LANG_FR)
+        return true;
+    else if ((utils::ends_with(str,"_ja") || str.find("/ja/") != std::string::npos) && language != Language::LANG_JP)
+        return true;
+    else if ((utils::ends_with(str,"_de") || str.find("/de/") != std::string::npos) && language != Language::LANG_DE)
+        return true;
+    else if ((utils::ends_with(str,"_es") || str.find("/es/") != std::string::npos) && language != Language::LANG_ES)
+        return true;
+    else if ((utils::ends_with(str,"_it") || str.find("/it/") != std::string::npos) && language != Language::LANG_IT)
+        return true;
+
+    return false;
+}
+
+bool languageFromSectionName(const std::string& name, Language& language)
+{
+    struct LangCode
+    {
+        const char* code;
+        Language language;
+    };
+
+    static const LangCode kCodes[] =
+    {
+        { "_jp", LANG_JP },
+        { "_en", LANG_EN },
+        { "_fr", LANG_FR },
+        { "_de", LANG_DE },
+        { "_it", LANG_IT },
+        { "_es", LANG_ES }
+    };
+
+    if (name.size() < 3)
+        return false;
+
+    const std::string suffix = name.substr(name.size() - 3);
+
+    for (const auto& entry : kCodes)
+    {
+        if (suffix == entry.code)
+        {
+            language = entry.language;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+} // namespace ndsloc

--- a/src/plugins/localization/lang.h
+++ b/src/plugins/localization/lang.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <stdint.h>
+#include <vector>
+#include <string>
+
+namespace ndsloc {
+
+enum Language : uint8_t
+{
+    LANG_JP = 0,
+    LANG_EN = 1,
+    LANG_FR = 2,
+    LANG_DE = 3,
+    LANG_IT = 4,
+    LANG_ES = 5,
+    LANG_COUNT = 6
+};
+
+bool languageFromSectionName(const std::string& name, Language& language);
+std::string getLanguageFileName(Language language);
+std::string getLanguageName(Language language);
+bool shouldIgnoreFile(const std::string& filename, Language language);
+
+} // namespace ndsloc

--- a/src/plugins/localization/lzss.cpp
+++ b/src/plugins/localization/lzss.cpp
@@ -1,0 +1,390 @@
+#include "lzss.h"
+
+#include <assert.h>
+
+#include "utils.h"
+
+namespace ndsloc {
+
+namespace {
+
+const int BlockSize = 8;
+const int SlidingWindowSize = 4096;
+const int MinMatchLength = 3;
+
+const int LzssMaxMatchLength = 18;
+const uint8_t LzssCompressionType = 0x10;
+
+const int OnzMaxMatchLength = 0x10110;
+const uint8_t OnzCompressionType = 0x11;
+
+}
+
+LZSSFile::LZSSFile(const std::string& inputPath)
+{
+    m_inputBuffer = utils::readBinaryFile(inputPath);
+    m_inputPtr = m_inputBuffer.data();
+    m_inputSize = m_inputBuffer.size();
+}
+
+LZSSFile::LZSSFile(const uint8_t* inputPtr, int inputSize)
+    : m_inputPtr(inputPtr)
+    , m_inputSize(inputSize)
+{
+}
+
+LZSSFile::ECompressType LZSSFile::getCompressionMethod() const
+{
+    assert(m_inputSize > 0 && m_inputPtr != nullptr);
+
+    if (m_inputPtr[0] == LzssCompressionType)
+        return ECompressType::LZSS;
+    else if (m_inputPtr[0] == OnzCompressionType)
+        return ECompressType::ONZ;
+    else
+        return ECompressType::Unknown;
+}
+
+void LZSSFile::decompress()
+{
+    auto algo = getCompressionMethod();
+    switch (algo)
+    {
+    case ECompressType::LZSS:
+        decompressLzss();
+        break;
+    case ECompressType::ONZ:
+        decompressOnz();
+        break;
+    default: {}
+        // Not implemented
+    }
+}
+
+
+void LZSSFile::decompressLzss()
+{
+    int currentPosition = 4;
+    int distance = 1;
+
+    const uint8_t* compressedData = m_inputPtr;
+    const int inputSize = m_inputSize;
+
+    int outputSize = compressedData[1] + (compressedData[2] << 8) + (compressedData[3] << 16);
+    m_outputBuffer.resize(outputSize);
+    uint8_t* outPtrStart = m_outputBuffer.data();
+    uint8_t* outPtr = outPtrStart;
+
+    int processedBytes = 0;
+    while (processedBytes <= outputSize && currentPosition < inputSize)
+    {
+        int forward = 1;
+        for (int i = 0; i < 8; i++)
+        {
+            if (currentPosition + forward >= inputSize)
+            {
+                break;
+            }
+
+            if (processedBytes >= outputSize)
+            {
+                break;
+            }
+
+            if (((compressedData[currentPosition] >> (7 - i)) & 1) == 1)
+            {
+                int amountToCopy = 3 + ((compressedData[currentPosition + forward] >> 4) & 0xF);
+                int copyFrom = distance + ((compressedData[currentPosition + forward] & 0xF) << 8)
+                    + compressedData[currentPosition + forward + 1];
+                int copyPosition = processedBytes - copyFrom;
+                for (int u = 0; u < amountToCopy; u++)
+                {
+                    const int readPosition = copyPosition + (u % copyFrom);
+                    if (readPosition >= 0 && readPosition < processedBytes)
+                    {
+                        *outPtr = outPtrStart[readPosition];
+                        outPtr++;
+                        processedBytes++;
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+
+                forward += 2;
+            }
+            else
+            {
+                *outPtr = compressedData[currentPosition + forward];
+                outPtr++;
+
+                processedBytes++;
+                forward++;
+            }
+        }
+
+        currentPosition += forward;
+    }
+
+    while (processedBytes < outputSize)
+    {
+        *outPtr = 0;
+        outPtr++;
+
+        processedBytes++;
+    }
+}
+
+void LZSSFile::decompressOnz()
+{
+    int currentPosition = 4;
+
+    const uint8_t* compressedData = m_inputPtr;
+    const int inputSize = m_inputSize;
+
+    int outputSize = compressedData[1] + (compressedData[2] << 8) + (compressedData[3] << 16);
+    m_outputBuffer.resize(outputSize);
+    uint8_t* outPtrStart = m_outputBuffer.data();
+    uint8_t* outPtr = outPtrStart;
+
+    int processedBytes = 0;
+    while (processedBytes <= outputSize && currentPosition < inputSize)
+    {
+        int forward = 1;
+        for (int i = 0; i < 8; i++)
+        {
+            if (currentPosition + forward >= inputSize)
+            {
+                break;
+            }
+
+            if (processedBytes >= outputSize)
+            {
+                break;
+            }
+
+            if (((compressedData[currentPosition] >> (7 - i)) & 1) == 1)
+            {
+                int amountToCopy;
+                int copyFrom;
+                uint8_t byte1 = compressedData[currentPosition + forward];
+                uint8_t byte2 = compressedData[currentPosition + forward + 1];
+
+                if ((byte1 & 0xF0) == 0x10)
+                {
+                    uint8_t byte3 = compressedData[currentPosition + forward + 2];
+                    uint8_t byte4 = compressedData[currentPosition + forward + 3];
+
+                    amountToCopy = 0x111 + ((byte1 & 0xF) << 12) + (byte2 << 4) + (byte3 >> 4);
+                    copyFrom = 1 + ((byte3 & 0xF) << 8) + byte4;
+                    forward += 4;
+                }
+                else if ((byte1 & 0xF0) == 0x00)
+                {
+                    uint8_t byte3 = compressedData[currentPosition + forward + 2];
+
+                    amountToCopy = 0x11 + ((byte1 & 0xF) << 4) + (byte2 >> 4);
+                    copyFrom = 1 + ((byte2 & 0xF) << 8) + byte3;
+                    forward += 3;
+                }
+                else
+                {
+                    amountToCopy = 0x1 + (byte1 >> 4);
+                    copyFrom = 1 + ((byte1 & 0xF) << 8) + byte2;
+                    forward += 2;
+                }
+
+                int copyPosition = processedBytes - copyFrom;
+                for (int u = 0; u < amountToCopy; u++)
+                {
+                    const int readPosition = copyPosition + (u % copyFrom);
+                    if (readPosition >= 0 && readPosition < processedBytes)
+                    {
+                        *outPtr = outPtrStart[readPosition];
+                        outPtr++;
+                        processedBytes++;
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+            }
+            else
+            {
+                *outPtr = compressedData[currentPosition + forward];
+                outPtr++;
+
+                processedBytes++;
+                forward++;
+            }
+        }
+
+        currentPosition += forward;
+    }
+
+    while (processedBytes < outputSize)
+    {
+        *outPtr = 0;
+        outPtr++;
+
+        processedBytes++;
+    }
+}
+
+void LZSSFile::saveToDisk(const std::string& outPath)
+{
+    utils::saveBinaryFile(m_outputBuffer, outPath);
+}
+
+void LZSSFile::compress(ECompressType type)
+{
+    switch (type)
+    {
+    case ECompressType::LZSS:
+        compressLzss();
+        break;
+    case ECompressType::ONZ:
+        compressOnz();
+        break;
+    default:
+        assert(false);
+    }
+}
+
+void LZSSFile::compressLzss()
+{
+    assert(m_inputSize > 0 && m_inputPtr != nullptr);
+
+    compress_impl(ECompressType::LZSS);
+}
+
+void LZSSFile::compressOnz()
+{
+    assert(m_inputSize > 0 && m_inputPtr != nullptr);
+
+    compress_impl(ECompressType::ONZ);
+}
+
+std::pair<int, int> LZSSFile::search(const uint8_t* data, int position, int size, int maxLength, int maxDistance)
+{
+    const int remaining = size - position;
+    if (remaining <= 0)
+        return { 0, 0 };
+
+    maxLength = std::min(maxLength, remaining);
+
+    const int start = std::max(0, position - maxDistance);
+
+    int bestDistance = 0;
+    int bestLength = 0;
+
+    for (int candidate = start; candidate < position; candidate++)
+    {
+        const int distance = position - candidate;
+
+        int length = 0;
+        while (length < maxLength && data[candidate + (length % distance)] == data[position + length])
+        {
+            length++;
+        }
+
+        if (length > bestLength)
+        {
+            bestLength = length;
+            bestDistance = distance;
+
+            if (bestLength == maxLength)
+            {
+                break;
+            }
+        }
+    }
+
+    return { bestDistance, bestLength };
+}
+
+void LZSSFile::encodeToken(std::vector<uint8_t>& out, int length, int distance, ECompressType type)
+{
+    const int offset = distance - 1;
+
+    if (type == ECompressType::LZSS)
+    {
+        out.push_back((uint8_t)(((length - 3) << 4) | ((offset >> 8) & 0xF)));
+        out.push_back((uint8_t)(offset & 0xFF));
+        return;
+    }
+
+    if (length <= 0x10)
+    {
+        out.push_back((uint8_t)(((length - 1) << 4) | ((offset >> 8) & 0xF)));
+        out.push_back((uint8_t)(offset & 0xFF));
+    }
+    else if (length <= 0x110)
+    {
+        const int biasedLength = length - 0x11;
+        out.push_back((uint8_t)((biasedLength >> 4) & 0xF));
+        out.push_back((uint8_t)(((biasedLength & 0xF) << 4) | ((offset >> 8) & 0xF)));
+        out.push_back((uint8_t)(offset & 0xFF));
+    }
+    else
+    {
+        const int biasedLength = length - 0x111;
+        out.push_back((uint8_t)(0x10 | ((biasedLength >> 12) & 0xF)));
+        out.push_back((uint8_t)((biasedLength >> 4) & 0xFF));
+        out.push_back((uint8_t)(((biasedLength & 0xF) << 4) | ((offset >> 8) & 0xF)));
+        out.push_back((uint8_t)(offset & 0xFF));
+    }
+}
+
+void LZSSFile::compress_impl(ECompressType type)
+{
+    const uint8_t* uncompressedData = m_inputPtr;
+    const int inputSize = m_inputSize;
+
+    const int maxMatchLength = (type == ECompressType::ONZ) ? OnzMaxMatchLength : LzssMaxMatchLength;
+    const uint8_t compressionType = (type == ECompressType::ONZ) ? OnzCompressionType : LzssCompressionType;
+
+    m_outputBuffer.clear();
+
+    // Header
+    m_outputBuffer.push_back(compressionType);
+    m_outputBuffer.push_back(inputSize & 0xff);
+    m_outputBuffer.push_back((inputSize >> 8) & 0xff);
+    m_outputBuffer.push_back((inputSize >> 16) & 0xff);
+
+    std::vector<uint8_t> blockContent;
+    int position = 0;
+
+    while (position < inputSize)
+    {
+        blockContent.clear();
+        uint8_t blockFlags = 0;
+
+        for (int i = BlockSize - 1; i >= 0 && position < inputSize; i--)
+        {
+            const std::pair<int, int> match = search(uncompressedData, position, inputSize, maxMatchLength, SlidingWindowSize);
+
+            const int distance = match.first;
+            const int length = match.second;
+
+            if (length >= MinMatchLength)
+            {
+                blockFlags |= (uint8_t)(1 << i);
+                encodeToken(blockContent, length, distance, type);
+                position += length;
+            }
+            else
+            {
+                blockContent.push_back(uncompressedData[position]);
+                position++;
+            }
+        }
+
+        m_outputBuffer.push_back(blockFlags);
+        m_outputBuffer.insert(m_outputBuffer.end(), blockContent.begin(), blockContent.end());
+    }
+}
+
+} // namespace ndsloc

--- a/src/plugins/localization/lzss.h
+++ b/src/plugins/localization/lzss.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cstdint>
+
+namespace ndsloc {
+
+class LZSSFile
+{
+public:
+    LZSSFile(const std::string& inputPath);
+    LZSSFile(const uint8_t* inputPtr, int inputSize);
+
+    enum ECompressType : uint8_t { LZSS = 0, ONZ, Unknown };
+
+    ECompressType getCompressionMethod() const;
+    void decompress();
+    void compress(ECompressType type = LZSS);
+
+    const std::vector<uint8_t>& getConvertedData() const { return m_outputBuffer; }
+    void saveToDisk(const std::string& outPath);
+
+private:
+    void decompressLzss();
+    void decompressOnz();
+
+    void compressLzss();
+    void compressOnz();
+
+    void compress_impl(ECompressType type);
+
+    static std::pair<int, int> search(const uint8_t* data, int position, int size, int maxLength, int maxDistance);
+    static void encodeToken(std::vector<uint8_t>& out, int length, int distance, ECompressType type);
+
+    std::vector<uint8_t> m_inputBuffer;
+    const uint8_t* m_inputPtr = nullptr;
+    int m_inputSize = 0;
+
+    std::vector<uint8_t> m_outputBuffer;
+};
+
+} // namespace ndsloc

--- a/src/plugins/localization/nds.cpp
+++ b/src/plugins/localization/nds.cpp
@@ -1,6 +1,7 @@
 #include "nds.h"
 
 #include <string>
+#include <cstring>
 #include <algorithm>
 #include <memory>
 #include <stdexcept>

--- a/src/plugins/localization/nds.cpp
+++ b/src/plugins/localization/nds.cpp
@@ -1,0 +1,343 @@
+#include "nds.h"
+
+#include <string>
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+
+#include "utils.h"
+
+#define HEADERCOUNT 8
+#define OVERLAY_FMT	"/FSI.CT/overlay%d_%04d.bin"
+
+namespace NDS {
+
+using BYTE = int8_t;
+using UINT = uint32_t;
+using WORD = int16_t;
+
+#pragma pack(push, 1)
+struct NDSHEADER
+{
+	char GameTitle[0x0C];
+	char GameCode[0x04];
+	char MakerCode[0x02];
+	BYTE UnitCode;
+	BYTE DeviceCode;						// type of device in the game card
+	BYTE DeviceCap;							// device capacity (128kb<<n Mbit)
+	BYTE Reserved_0x015[0x09];				// (zero filled)
+	BYTE RomVersion;
+	BYTE Autostart;							// (Bit2: Skip "Press Button" after Health and Safety) (Also skips bootmenu, even in Manual mode & even Start pressed)
+	UINT Arm9_Rom_Offset;					// copy src
+	UINT Arm9_Entry_Address;				// entry point
+	UINT Arm9_Ram_Address;					// copy dst
+	UINT Arm9_Size;							// size
+	UINT Arm7_Rom_Offset;
+	UINT Arm7_Entry_Address;
+	UINT Arm7_Ram_Address;
+	UINT Arm7_Size;
+	UINT Fnt_Offset;
+	UINT Fnt_Size;
+	UINT Fat_Offset;
+	UINT Fat_Size;
+	UINT Arm9_Overlay_Offset;
+	UINT Arm9_Overlay_Size;
+	UINT Arm7_Overlay_Offset;
+	UINT Arm7_Overlay_Size;
+	UINT Port_40001A4h_Normal_Commands;		// Port 40001A4h setting for normal commands (usually 00586000h)
+	UINT Port_40001A4h_KEY1_Commands;		// Port 40001A4h setting for KEY1 commands   (usually 001808F8h)
+	UINT Banner_Offset;
+	WORD Secure_Area_CRC;
+	WORD Secure_Area_Loading_Timeout;
+	UINT ARM9_Auto_Load_List_RAM_Address;	// ?
+	UINT ARM7_Auto_Load_List_RAM_Address;	// ?
+	UINT Secure_Area_Disable1;				// unique ID for homebrew
+	UINT Secure_Area_Disable2;				// unique ID for homebrew
+	UINT Application_End_Offset;			// Total Used ROM size
+	UINT Rom_Header_Size;
+	BYTE Reserved_0x088[0x38];				// Reserved (zero filled)
+	BYTE Nintendo_Logo[0x9C];
+	WORD Nintendo_Logo_CRC;
+	WORD Header_CRC;
+	UINT Debug_Rom_Offset;					// (0=none) (8000h and up)       ;only if debug
+	UINT Debug_Size;						// (0=none) (max 3BFE00h)        ;version with
+	UINT Debug_Ram_Address;					// (0=none) (2400000h..27BFE00h) ;SIO and 8MB
+	UINT Reserved_0x16C;
+	BYTE Zero[0x90];
+};
+
+struct OVERLAYENTRY
+{
+	UINT id;
+	UINT ram_address;
+	UINT ram_size;
+	UINT bss_size;
+	UINT sinit_init;
+	UINT sinit_init_end;
+	UINT file_id;
+	UINT reserved;
+};
+
+struct NDSSPECREC {
+	UINT nTop;
+	UINT nBottom;
+	std::string FileName;
+};
+
+struct NDSFILEREC
+{
+	UINT top;
+	UINT bottom;	// size = bottom-top
+};
+
+struct NDSDIRREC
+{
+	UINT entry_start;
+	WORD top_file_id;
+	WORD parent_id_or_count;
+};
+#pragma pack(pop)
+
+template<typename ... Args>
+std::string string_format(const std::string& format, Args ... args)
+{
+	int size_s = std::snprintf(nullptr, 0, format.c_str(), args ...) + 1;
+	if (size_s <= 0) { throw std::runtime_error("Error during formatting."); }
+	auto size = static_cast<size_t>(size_s);
+	std::unique_ptr<char[]> buf(new char[size]);
+	std::snprintf(buf.get(), size, format.c_str(), args ...);
+	return std::string(buf.get(), buf.get() + size - 1);
+}
+
+void string_tolower(std::string& str)
+{
+	std::transform(str.begin(), str.end(), str.begin(), [](unsigned char c) { return std::tolower(c); });
+}
+
+std::string getFileExtension(const std::string& path)
+{
+	const std::size_t sep = path.find_last_of("/\\");
+	const std::size_t start = (sep == std::string::npos) ? 0 : sep + 1;
+	const std::size_t dot = path.find_last_of('.');
+
+	if (dot == std::string::npos || dot < start || dot == start || dot + 1 == path.size())
+		return {};
+
+	return path.substr(dot + 1);
+}
+
+NDSEntry::NDSEntry(const std::string& in_filename, const std::string& ext, int in_start, int in_size, int in_fileId)
+	: filename(in_filename)
+	, type(ext)
+	, start(in_start)
+	, size(in_size)
+	, maxSize(in_size)
+	, fileId(in_fileId)
+{
+	string_tolower(type);
+}
+
+NDSFileSystem::NDSFileSystem(uint8_t* rom, uint32_t romSize)
+	: m_pRom (rom)
+	, m_nRomSize(romSize)
+{
+}
+
+void NDSFileSystem::getRomFileSystem(bool bSkipOverlays)
+{
+	auto* m_pHeader = (NDSHEADER*)m_pRom;
+
+	std::string OverlayFiles = "/FSI.CT/";
+
+	UINT nArm9_Size = m_pHeader->Arm9_Size;
+	if (*(UINT*)(m_pRom + m_pHeader->Arm9_Rom_Offset + nArm9_Size) == 0xDEC00621)
+		nArm9_Size += 4 * 4;	// arm9.bin with_footer
+
+	NDSSPECREC SpecRec[HEADERCOUNT] = {
+		//Top	Bottom			Name
+		{0, sizeof(NDSHEADER), OverlayFiles + "/FSI.CT/ndsheader.bin" },
+		{m_pHeader->Arm9_Rom_Offset, m_pHeader->Arm9_Rom_Offset + nArm9_Size, OverlayFiles + "arm9.bin" },
+		{m_pHeader->Arm7_Rom_Offset, m_pHeader->Arm7_Rom_Offset + m_pHeader->Arm7_Size, OverlayFiles + "arm7.bin" },
+		{m_pHeader->Arm9_Overlay_Offset, m_pHeader->Arm9_Overlay_Offset + m_pHeader->Arm9_Overlay_Size, OverlayFiles + "arm9ovltable.bin" },
+		{m_pHeader->Arm7_Overlay_Offset, m_pHeader->Arm7_Overlay_Offset + m_pHeader->Arm7_Overlay_Size, OverlayFiles + "arm7ovltable.bin" },
+		{m_pHeader->Fnt_Offset, m_pHeader->Fnt_Offset + m_pHeader->Fnt_Size, OverlayFiles + "fnt.bin" },
+		{m_pHeader->Fat_Offset, m_pHeader->Fat_Offset + m_pHeader->Fat_Size, OverlayFiles + "fat.bin" },
+		{m_pHeader->Banner_Offset, m_pHeader->Banner_Offset + 0x840, OverlayFiles + "banner.bin" }
+	};
+
+	if (!bSkipOverlays)
+	{
+		UINT m_nOverlayFiles9 = m_pHeader->Arm9_Overlay_Size / sizeof(OVERLAYENTRY);
+		UINT m_nOverlayFiles7 = m_pHeader->Arm7_Overlay_Size / sizeof(OVERLAYENTRY);
+
+		UINT m_nOverlayFileSize = 0;
+		OVERLAYENTRY OverlayEntry;
+		NDSFILEREC* pFileRec;
+		for (UINT i = 0; i < m_nOverlayFiles9; i++)
+		{
+			OverlayFiles = string_format(OVERLAY_FMT, 9, i);
+			memcpy(&OverlayEntry, m_pRom + m_pHeader->Arm9_Overlay_Offset + sizeof(OverlayEntry) * i, sizeof(OverlayEntry));
+
+			pFileRec = (NDSFILEREC*)(m_pRom + m_pHeader->Fat_Offset + (OverlayEntry.file_id << 3));
+			m_nOverlayFileSize += pFileRec->bottom - pFileRec->top;
+
+			addEntry(OverlayFiles, pFileRec->top, pFileRec->bottom - pFileRec->top, static_cast<int>(OverlayEntry.file_id));
+		}
+
+		for (UINT i = 0; i < m_nOverlayFiles7; i++)
+		{
+			OverlayFiles = string_format(OVERLAY_FMT, 7, i);
+			memcpy(&OverlayEntry, m_pRom + m_pHeader->Arm7_Overlay_Offset + sizeof(OverlayEntry) * i, sizeof(OverlayEntry));
+
+			pFileRec = (NDSFILEREC*)(m_pRom + m_pHeader->Fat_Offset + (OverlayEntry.file_id << 3));
+			m_nOverlayFileSize += pFileRec->bottom - pFileRec->top;
+
+			addEntry(OverlayFiles, pFileRec->top, pFileRec->bottom - pFileRec->top, static_cast<int>(OverlayEntry.file_id));
+		}
+	}
+
+	OverlayFiles = "/";
+	extractDirectory(OverlayFiles);
+
+	computeMaxSizes();
+}
+
+void NDSFileSystem::computeMaxSizes()
+{
+	if (m_foundEntries.empty())
+		return;
+
+	std::vector<NDSEntry*> sorted;
+	sorted.reserve(m_foundEntries.size());
+	for (auto& entry : m_foundEntries)
+		sorted.push_back(&entry);
+
+	std::sort(sorted.begin(), sorted.end(), [](const NDSEntry* a, const NDSEntry* b) { return a->start < b->start; });
+
+	size_t i = 0;
+	while (i < sorted.size())
+	{
+		size_t next = i;
+		while (next < sorted.size() && sorted[next]->start == sorted[i]->start)
+			next++;
+
+		const int nextStart = (next < sorted.size()) ? sorted[next]->start : static_cast<int>(m_nRomSize);
+
+		for (size_t k = i; k < next; k++)
+			sorted[k]->maxSize = std::max(nextStart - sorted[k]->start, sorted[k]->size);
+
+		i = next;
+	}
+}
+
+void NDSFileSystem::extractDirectory(const std::string& ParentDir, uint8_t nID)
+{
+	std::string strFilePathName;
+	BYTE nRecLen;
+	bool bIsDir;
+	std::string Dir = ParentDir;
+
+	auto* m_pHeader = (NDSHEADER*)m_pRom;
+
+	UINT nPos = m_pHeader->Fnt_Offset+(nID<<3);
+	if(m_nRomSize < nPos)
+		return;
+
+	NDSDIRREC* pDirRec = (NDSDIRREC*)(m_pRom +nPos);
+	nPos = m_pHeader->Fnt_Offset + pDirRec->entry_start;
+	if(m_nRomSize < nPos)
+		return;
+
+	char m_FileName[0x80];
+
+	const uint8_t* pRec = m_pRom + nPos;
+	UINT FileID = pDirRec->top_file_id;
+	while(1)
+	{
+		nRecLen = *(pRec++);	if(nRecLen==0) break;
+		bIsDir = nRecLen&0x80; nRecLen&=0x7F;
+
+		memcpy(m_FileName, pRec, nRecLen);
+		pRec+=nRecLen;
+		m_FileName[nRecLen]=0;
+		if(bIsDir)
+		{
+			WORD DirID = *(WORD*)(pRec);DirID&=0xFFF;
+			pRec+=2;
+			Dir = string_format("%s%s/", ParentDir.c_str(), m_FileName);
+			extractDirectory(Dir, DirID);
+			continue;
+		}
+		NDSFILEREC *pFileRec;
+		pFileRec = (NDSFILEREC*)(m_pRom+m_pHeader->Fat_Offset+(FileID<<3));
+		nPos = pFileRec->bottom - pFileRec->top;
+
+		strFilePathName = string_format("%s%s", ParentDir.c_str(), m_FileName);
+
+		addEntry(strFilePathName, pFileRec->top, nPos, static_cast<int>(FileID));
+		FileID++;
+	}
+}
+
+void NDSFileSystem::addEntry(std::string& path, int start, int size, int fileId)
+{
+	auto ext = getFileExtension(path);
+	if (ext.empty())
+	{
+		auto type = utils::getFileFormat(m_pRom + start, size);
+		ext = utils::getExtName(type);
+	}
+
+	m_foundEntries.emplace_back(path, ext, start, size, fileId);
+}
+
+NDSEntry* NDSFileSystem::findEntryByOffset(uint32_t offset)
+{
+	for (auto& entry : m_foundEntries)
+	{
+		if (offset >= entry.start && offset <= entry.start + entry.size)
+			return &entry;
+	}
+
+	return nullptr;
+}
+
+NDSEntry* NDSFileSystem::findEntryByName(const std::string& name)
+{
+	for (auto& entry : m_foundEntries)
+	{
+		if (entry.filename.find(name) != std::string::npos)
+			return &entry;
+	}
+
+	return nullptr;
+}
+
+bool NDSFileSystem::patchEntrySize(NDSEntry& entry, int newSize)
+{
+	if (m_pRom == nullptr)
+		return false;
+
+	if (entry.fileId < 0)
+		return false;
+
+	if (newSize < 0 || newSize > entry.maxSize)
+		return false;
+
+	auto* pHeader = (const NDSHEADER*)m_pRom;
+
+	const UINT nPos = pHeader->Fat_Offset + (static_cast<UINT>(entry.fileId) << 3);
+	if (nPos + sizeof(NDSFILEREC) > m_nRomSize)
+		return false;
+
+	NDSFILEREC* pFileRec = (NDSFILEREC*)(m_pRom + nPos);
+	if (pFileRec->top != static_cast<UINT>(entry.start))
+		return false;
+
+	pFileRec->bottom = pFileRec->top + static_cast<UINT>(newSize);
+	entry.size = newSize;
+
+	return true;
+}
+
+} // namespace NDS

--- a/src/plugins/localization/nds.h
+++ b/src/plugins/localization/nds.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cstdint>
+
+namespace NDS {
+
+struct NDSEntry
+{
+	NDSEntry(const std::string& in_filename, const std::string& ext, int in_start, int in_size, int in_fileId);
+
+	std::string filename;
+	std::string type;
+	int start = 0;
+	int size = 0;
+	int maxSize = 0;
+	int fileId = -1;
+};
+
+class NDSFileSystem
+{
+public:
+	NDSFileSystem(uint8_t* rom, uint32_t romSize);
+
+	void getRomFileSystem(bool bSkipOverlays = false);
+
+	void extractDirectory(const std::string& ParentDir, uint8_t nID = 0);
+
+	void computeMaxSizes();
+
+	NDSEntry* findEntryByOffset(uint32_t offset);
+	NDSEntry* findEntryByName(const std::string& name);
+
+	bool patchEntrySize(NDSEntry& entry, int newSize);
+	const std::vector<NDSEntry>& getAllEntries() const { return m_foundEntries; }
+
+private:
+	void addEntry(std::string& path, int start, int size, int fileId);
+
+	uint8_t* m_pRom = nullptr;
+	uint32_t m_nRomSize = 0;
+
+	std::vector<NDSEntry> m_foundEntries;
+};
+
+} // namespace NDS

--- a/src/plugins/localization/p2.cpp
+++ b/src/plugins/localization/p2.cpp
@@ -1,0 +1,325 @@
+#include "p2.h"
+
+#include <filesystem>
+#include <assert.h>
+#include <cstring>
+#include <fstream>
+
+#include "utils.h"
+#include "lang.h"
+#include "lzss.h"
+#include "strings.h"
+#include "cakp.h"
+#include "stringtable.h"
+#include "rompatcher.h"
+
+namespace ndsloc {
+
+namespace p2 {
+
+bool isP2File(const uint8_t* buffer)
+{
+    return (std::memcmp(buffer, "P2", 2) == 0);
+}
+
+} // namespace p2
+
+P2File::P2File(const std::string& filePath)
+    : m_language(LANG_EN)
+{
+    m_inputBuffer = utils::readBinaryFile(filePath);
+    m_inputPtr = m_inputBuffer.data();
+    m_inputSize = m_inputBuffer.size();
+}
+
+P2File::P2File(uint8_t* inputPtr, uint32_t inputSize)
+    : m_inputPtr(inputPtr)
+    , m_inputSize(inputSize)
+    , m_language(LANG_EN)
+{
+}
+
+bool P2File::sizeTableLooksValid(uint32_t sizesAt) const
+{
+    const uint32_t fileCount = static_cast<uint32_t>(m_subfiles.size());
+
+    if (sizesAt + fileCount * 4 > m_inputSize)
+        return false;
+
+    for (uint32_t i = 0; i < fileCount; ++i)
+    {
+        const uint32_t offset = m_subfiles[i].fileOffset;
+        const uint32_t size = utils::readUInt24(m_inputPtr, sizesAt + i * 4);
+        const uint8_t flag = m_inputPtr[sizesAt + i * 4 + 3];
+
+        if (offset > m_inputSize || size > m_inputSize - offset)
+            return false;
+
+        if (size > m_subfiles[i].maxSize)
+            return false;
+
+        if ((flag & p2::kFlagCompressed) != 0 &&
+            m_inputPtr[offset] != p2::kLZ10 && m_inputPtr[offset] != p2::kLZ11)
+            return false;
+    }
+
+    return true;
+}
+
+const std::vector<P2SubFile>& P2File::readAndGetFileTable()
+{
+    readFileTable();
+    return m_subfiles;
+}
+
+bool P2File::readFileTable()
+{
+    m_subfiles.clear();
+
+    uint8_t* dataPtr = m_inputPtr;
+    const uint32_t inputSize = m_inputSize;
+
+    if (!p2::isP2File(dataPtr) || inputSize < p2::kSectorTableAt)
+        return false; // Not a P2 file
+
+    const uint8_t fileCount = dataPtr[2];
+    const uint8_t fileType = dataPtr[3];
+    const uint32_t firstFileOffset = utils::readUInt24(dataPtr, 0x0C);
+
+    if (fileCount == 0)
+        return false;
+
+    if (fileType != p2::kTypePlain && fileType != p2::kTypeNamed)
+        return false; // Unknown P2 type
+
+    uint32_t currentPos = p2::kSectorTableAt;
+    if (currentPos + fileCount * 2 > inputSize)
+        return false;
+
+    m_subfiles.resize(fileCount);
+
+    for (int i = 0; i < fileCount; i++)
+    {
+        uint16_t val = utils::readUInt16(dataPtr, currentPos);
+        m_subfiles[i].fileOffset = firstFileOffset + val * p2::kSectorSize;
+        m_subfiles[i].chunkId = static_cast<uint16_t>(i);
+        currentPos += 2;
+    }
+
+    for (int i = 0; i < fileCount; i++)
+    {
+        auto& fileDesc = m_subfiles[i];
+
+        if (fileDesc.fileOffset > inputSize)
+            return false;
+
+        if (i + 1 < fileCount)
+        {
+            auto& nextFileDesc = m_subfiles[i + 1];
+            if (nextFileDesc.fileOffset > fileDesc.fileOffset)
+                fileDesc.maxSize = nextFileDesc.fileOffset - fileDesc.fileOffset;
+            else
+                fileDesc.maxSize = 0;
+        }
+        else
+        {
+            fileDesc.maxSize = inputSize - fileDesc.fileOffset;
+        }
+    }
+
+    currentPos = (currentPos + 3u) & ~3u;
+
+    const uint32_t sizesAt = sizeTableLooksValid(currentPos) ? currentPos : 0;
+
+    if (sizesAt != 0)
+    {
+        for (int i = 0; i < fileCount; i++)
+        {
+            auto& fileDesc = m_subfiles[i];
+
+            fileDesc.fileSize = utils::readUInt24(dataPtr, sizesAt + i * 4);
+            fileDesc.someFlag = dataPtr[sizesAt + i * 4 + 3];
+        }
+
+        currentPos = sizesAt + fileCount * 4;
+    }
+    else
+    {
+        // No usable size table: fall back to the sector span and sniff the
+        // payload for a codec marker instead of assuming compression.
+        for (int i = 0; i < fileCount; i++)
+        {
+            auto& fileDesc = m_subfiles[i];
+
+            fileDesc.fileSize = fileDesc.maxSize;
+
+            const uint8_t first = dataPtr[fileDesc.fileOffset];
+            fileDesc.someFlag = (first == p2::kLZ10 || first == p2::kLZ11)
+                ? p2::kFlagCompressed
+                : 0;
+        }
+
+        currentPos += fileCount * 4;
+    }
+
+    // --- name table: 8 bytes per entry, NUL-padded ---
+    if (fileType == p2::kTypeNamed && currentPos + fileCount * p2::kNameLength <= inputSize)
+    {
+        for (int i = 0; i < fileCount; i++)
+        {
+            auto& fileDesc = m_subfiles[i];
+
+            const char* name = reinterpret_cast<const char*>(dataPtr + currentPos);
+            fileDesc.fileName = std::string(name, strnlen(name, p2::kNameLength));
+            currentPos += p2::kNameLength;
+        }
+    }
+
+    for (int i = 0; i < fileCount; i++)
+    {
+        auto& fileDesc = m_subfiles[i];
+        fileDesc.inputPtr = dataPtr + fileDesc.fileOffset;
+    }
+
+    return true;
+}
+
+void P2File::saveToDisk(const std::string& outPath)
+{
+    utils::saveBinaryFile(m_inputBuffer, outPath);
+}
+
+void appendStrings(const std::vector<String>& strings, std::vector<String>& out)
+{
+    for (auto& str : strings)
+    {
+        if (str.text == "\x01")
+            continue;
+
+        out.push_back(std::move(str));
+    }
+}
+
+bool P2File::extractPayload(const P2SubFile& subfile, uint8_t* payload, uint32_t payloadSize, uint32_t payloadOffset, uint32_t depth, std::vector<String>& out)
+{
+    assert(subfile.fileOffset == payloadOffset);
+
+    if (payload == nullptr || payloadSize < 8)
+        return true; // stub entries
+
+    std::vector<String> strings;
+
+    if (cakp::isCAKP(payload))
+    {
+        CAKPFile cakp(payload, payloadSize, subfile.getFilename());
+        cakp.setLanguage(m_language);
+        const bool ok = cakp.extractStrings(strings);
+
+        appendStrings(strings, out);
+        return ok;
+    }
+
+    if (p2::isP2File(payload))
+    {
+        if (depth >= m_maxDepth)
+            return true;
+
+        P2File nested(payload, payloadSize);
+        nested.setLanguage(m_language);
+        //nested.setMaxDepth(m_maxDepth);
+
+        std::vector<String> nestedOut;
+        const bool ok = nested.extractStrings(nestedOut);
+        appendStrings(nestedOut, out);
+        return ok;
+    }
+
+    if (StringTableFile::looksValid(payload, payloadSize))
+    {
+        std::vector<U16String> wide;
+        StringTableFile table(payload, payloadSize);
+        const bool ok = table.extractStrings(wide);
+        strings::appendWideStrings(subfile.getFilename(), wide, out);
+        return ok;
+    }
+
+    CAKPFile section(payload, payloadSize, subfile.getFilename());
+    section.setLanguage(m_language);
+    section.extractSectionStrings(strings);
+    appendStrings(strings, out);
+    return true;
+}
+
+uint32_t getExpectedDecompressedSize(const uint8_t* dataPtr, uint32_t dataSize)
+{
+    if (dataSize < 4)
+        return 0;
+
+    const uint32_t packed = utils::readUInt24(dataPtr, 1);
+    if (packed != 0)
+        return packed;
+
+    return dataSize >= 8 ? utils::readUInt32(dataPtr, 4) : 0;
+}
+
+bool P2File::extractSubFile(const P2SubFile& subfile, uint32_t depth, std::vector<String>& out)
+{
+    if (subfile.fileSize == 0)
+        return true;
+
+    if (subfile.isCompressed())
+    {
+        ndsloc::LZSSFile lzss(subfile.inputPtr, subfile.fileSize);
+        lzss.decompress();
+
+        auto decompressed = lzss.getConvertedData();
+        auto* data = decompressed.data();
+        auto dataSize = static_cast<uint32_t>(decompressed.size());
+
+        const uint32_t expected = getExpectedDecompressedSize(subfile.inputPtr, subfile.maxSize);
+        assert(expected == dataSize);
+
+        return extractPayload(subfile, data, dataSize, subfile.fileOffset, depth, out);
+    }
+    else
+    {
+        return extractPayload(subfile, subfile.inputPtr, subfile.fileSize, subfile.fileOffset, depth, out);
+    }
+}
+
+void P2File::updateEntrySizeInTable(uint16_t subfileId, uint32_t newSize)
+{
+    // TODO: update this function
+
+    const uint8_t fileCount = m_subfiles.size();
+    uint8_t fileType = m_inputPtr[3];
+
+    if (fileType == 0x80)
+    {
+        P2SubFile& fileDesc = m_subfiles[subfileId];
+        const uint32_t currentPos = 0x10 + (2 * fileCount) + (4 * subfileId);
+
+        m_inputPtr[currentPos] = static_cast<uint8_t>(newSize & 0xFF);
+        m_inputPtr[currentPos + 1] = static_cast<uint8_t>((newSize >> 8) & 0xFF);
+        m_inputPtr[currentPos + 2] = static_cast<uint8_t>((newSize >> 16) & 0xFF);
+    }
+}
+
+bool P2File::extractStrings(std::vector<String>& out)
+{
+    out.clear();
+
+    if (!readFileTable())
+        return false;
+
+    bool ok = true;
+    for (const P2SubFile& subfile : m_subfiles)
+    {
+        if (!extractSubFile(subfile, 0, out))
+            ok = false;
+    }
+
+    return ok;
+}
+
+} // namespace ndsloc

--- a/src/plugins/localization/p2.h
+++ b/src/plugins/localization/p2.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "strings.h"
+
+namespace ndsloc {
+
+namespace strings {
+struct CsvNdsFile;
+}
+
+enum Language : uint8_t;
+
+namespace p2 {
+
+static const uint32_t kSectorTableAt = 0x10;
+static const uint32_t kSectorSize = 0x200;
+static const uint32_t kNameLength = 8;
+
+static const uint8_t kTypePlain = 0x00;
+static const uint8_t kTypeNamed = 0x80;
+
+static const uint8_t kFlagCompressed = 0x80;
+
+static const uint8_t kLZ10 = 0x10;
+static const uint8_t kLZ11 = 0x11;
+
+bool isP2File(const uint8_t* buffer);
+
+} // namespace p2
+
+struct P2SubFile
+{
+    uint16_t chunkId = 0;
+    std::string fileName;
+    uint32_t fileOffset = 0;
+    uint16_t fileSize = 0;
+    uint16_t maxSize = 0;
+    uint8_t someFlag = 0;
+
+    uint8_t* inputPtr = nullptr;
+
+    std::string getFilename() const
+    {
+        if (!fileName.empty())
+            return fileName;
+        else
+            return std::to_string(chunkId) + ".Z";
+    }
+
+    bool isCompressed() const
+    {
+        return (someFlag & p2::kFlagCompressed) != 0;
+    }
+};
+
+class P2File
+{
+public:
+    P2File(const std::string& filePath);
+    P2File(uint8_t* inputPtr, uint32_t inputSize);
+
+    const std::vector<P2SubFile>& readAndGetFileTable();
+
+    void setLanguage(Language language) { m_language = language; }
+
+    bool extractStrings(std::vector<String>& out);
+
+    void saveToDisk(const std::string& outPath);
+
+    void updateEntrySizeInTable(uint16_t subfileId, uint32_t newSize);
+private:
+    bool sizeTableLooksValid(uint32_t sizesAt) const;
+    bool readFileTable();
+
+    bool extractSubFile(const P2SubFile& subfile, uint32_t depth, std::vector<String>& out);
+    bool extractPayload(const P2SubFile& subfile, uint8_t* payload, uint32_t payloadSize, uint32_t payloadOffset, uint32_t depth, std::vector<String>& out);
+
+    std::vector<uint8_t> m_inputBuffer;
+    uint8_t* m_inputPtr = nullptr;
+    uint32_t m_inputSize = 0;
+    Language m_language;
+    static constexpr uint32_t m_maxDepth = 4;
+
+    std::vector<P2SubFile> m_subfiles;
+};
+
+
+} // namespace ndsloc

--- a/src/plugins/localization/rompatcher.cpp
+++ b/src/plugins/localization/rompatcher.cpp
@@ -1,0 +1,502 @@
+#include "rompatcher.h"
+
+#include "strings.h"
+#include "stringtable.h"
+#include "nds.h"
+#include "utils.h"
+#include "p2.h"
+#include "cakp.h"
+#include "lzss.h"
+
+#include <algorithm>
+#include <cstring>
+#include <assert.h>
+
+namespace ndsloc {
+namespace patcher {
+
+bool patchCompressedSection(uint8_t* inputPtr, uint32_t inputSize, uint32_t maxSize, const std::vector<strings::CsvLine>& lines, bool bPadFF, uint32_t& out_size, uint32_t& out_count);
+
+bool patchP2File(P2File& file, NDS::NDSFileSystem& fs, NDS::NDSEntry* entry, const strings::CsvNdsFile& patchData, uint32_t& out_count)
+{
+    auto& subfiles = file.readAndGetFileTable();
+
+    uint32_t updatedLines = 0;
+
+    for (auto& patchFile : patchData.subfiles)
+    {
+        auto found = std::find_if(subfiles.begin(), subfiles.end(), [&](auto& e) { return e.getFilename() == patchFile.filename; });
+        assert(found != subfiles.end());
+        if (found != subfiles.end())
+        {
+            auto& subfile = *found;
+            if (subfile.isCompressed())
+            {
+                uint32_t newSize = 0;
+                uint32_t lineCount = 0;
+                bool bNeedUpdate = patcher::patchCompressedSection(subfile.inputPtr, subfile.fileSize, subfile.maxSize, patchFile.lines, false, newSize, lineCount);
+                if (bNeedUpdate)
+                {
+                    uint16_t subfileIndex = std::distance(subfiles.begin(), found);
+                    file.updateEntrySizeInTable(subfileIndex, newSize);
+                    updatedLines += lineCount;
+                }
+            }
+            else
+            {
+                //assert(false);
+            }
+        }
+    }
+
+    out_count += updatedLines;
+    return (updatedLines > 0);
+}
+
+uint32_t createPatch(const std::string& romPath, const std::vector<strings::CsvNdsFile>& modFiles)
+{
+    auto ndsRom = utils::readBinaryFile(romPath);
+
+    uint32_t totalUpdatedLines = createPatch(ndsRom.data(), ndsRom.size(), modFiles);
+
+    utils::saveBinaryFile(ndsRom, romPath + "_mod");
+
+    return totalUpdatedLines;
+}
+
+uint32_t createPatch(uint8_t* rom, uint32_t romSize, const std::vector<strings::CsvNdsFile>& modFiles)
+{
+    auto ndsfs = NDS::NDSFileSystem(rom, romSize);
+    ndsfs.getRomFileSystem(true);
+
+    uint32_t totalUpdatedLines = 0;
+
+    for (auto& modFile : modFiles)
+    {
+        auto* entry = ndsfs.findEntryByName(modFile.filename);
+        assert(entry);
+        if (!entry)
+            continue;
+
+        auto* data = rom + entry->start;
+
+        if (entry->type == "p2")
+        {
+            auto p2file = ndsloc::P2File(data, entry->size);
+            uint32_t linesCount = 0;
+            bool bUpdated = patchP2File(p2file, ndsfs, entry, modFile, linesCount);
+            if (bUpdated)
+            {
+                totalUpdatedLines += linesCount;
+            }
+        }
+        else if (entry->type == "z")
+        {
+            uint32_t newSize = 0;
+            uint32_t linesCount = 0;
+            bool bNeedUpdate = patcher::patchCompressedSection(data, entry->size, entry->maxSize, modFile.lines, true, newSize, linesCount);
+            if (bNeedUpdate)
+            {
+                ndsfs.patchEntrySize(*entry, newSize);
+                totalUpdatedLines += linesCount;
+            }
+        }
+    }
+
+    return totalUpdatedLines;
+}
+
+enum class TextEncoding
+{
+    Utf8,
+    Utf16LE
+};
+
+struct PatchTarget
+{
+    uint8_t* buffer = nullptr;
+    uint32_t bufferSize = 0;  // whole decompressed subfile, for bounds checking
+    uint32_t offset = 0;      // where the string starts, from buffer
+    uint32_t capacity = 0;    // bytes the slot holds (includes terminator)
+    TextEncoding encoding = TextEncoding::Utf8;
+};
+
+enum class PatchStatus
+{
+    Ok,
+    BadTarget,
+    BadEncoding,
+    BadEscape,
+    BadSourceText,
+    TooLong
+};
+
+
+struct PatchResult
+{
+    PatchStatus status = PatchStatus::BadTarget;
+    uint32_t required = 0;
+    uint32_t written = 0;
+
+    bool ok() const { return status == PatchStatus::Ok; }
+};
+
+enum class PadMode
+{
+    Zero,
+    Spaces,
+    FF,
+};
+
+
+uint32_t encodedSizeUtf8(uint32_t cp)
+{
+    if (cp < 0x80)    return 1;
+    if (cp < 0x800)   return 2;
+    if (cp < 0x10000) return 3;
+    return 4;
+}
+
+uint32_t encodedSizeUtf16(uint32_t cp)
+{
+    return cp < 0x10000 ? 2u : 4u;
+}
+
+bool hexDigit(char c, uint32_t& value)
+{
+    if (c >= '0' && c <= '9') { value = static_cast<uint32_t>(c - '0'); return true; }
+    if (c >= 'a' && c <= 'f') { value = static_cast<uint32_t>(c - 'a') + 10; return true; }
+    if (c >= 'A' && c <= 'F') { value = static_cast<uint32_t>(c - 'A') + 10; return true; }
+    return false;
+}
+
+bool readHex(const char* text, size_t& at, uint32_t digits, uint32_t& value)
+{
+    value = 0;
+
+    for (uint32_t i = 0; i < digits; ++i)
+    {
+        uint32_t digit = 0;
+        if (text[at] == '\0' || !hexDigit(text[at], digit))
+            return false;
+
+        value = (value << 4) | digit;
+        ++at;
+    }
+
+    return true;
+}
+
+bool decodeUtf8(const char* text, size_t& at, uint32_t& cp)
+{
+    const uint8_t lead = static_cast<uint8_t>(text[at]);
+    uint32_t extra = 0;
+
+    if (lead < 0x80) { cp = lead;         extra = 0; }
+    else if ((lead & 0xE0) == 0xC0) { cp = lead & 0x1F;  extra = 1; }
+    else if ((lead & 0xF0) == 0xE0) { cp = lead & 0x0F;  extra = 2; }
+    else if ((lead & 0xF8) == 0xF0) { cp = lead & 0x07;  extra = 3; }
+    else return false;
+
+    ++at;
+
+    for (uint32_t i = 0; i < extra; ++i)
+    {
+        const uint8_t next = static_cast<uint8_t>(text[at]);
+        if ((next & 0xC0) != 0x80)
+            return false;
+
+        cp = (cp << 6) | (next & 0x3F);
+        ++at;
+    }
+
+    return cp <= 0x10FFFF;
+}
+
+PatchStatus decodeSource(const char* text, std::vector<uint32_t>& out)
+{
+    out.clear();
+
+    if (text == nullptr)
+        return PatchStatus::BadSourceText;
+
+    size_t at = 0;
+    while (text[at] != '\0')
+    {
+        if (text[at] != '\\')
+        {
+            uint32_t cp = 0;
+            if (!decodeUtf8(text, at, cp))
+                return PatchStatus::BadSourceText;
+
+            out.push_back(cp);
+            continue;
+        }
+
+        ++at;
+
+        const char escape = text[at];
+        uint32_t value = 0;
+
+        switch (escape)
+        {
+        case 'n':  out.push_back(0x0A); ++at; break;
+        case 't':  out.push_back(0x09); ++at; break;
+        case '\\': out.push_back('\\'); ++at; break;
+
+        case 'x':
+            ++at;
+            if (!readHex(text, at, 2, value))
+                return PatchStatus::BadEscape;
+            out.push_back(value);
+            break;
+
+        case 'u':
+            ++at;
+            if (!readHex(text, at, 4, value))
+                return PatchStatus::BadEscape;
+            out.push_back(value);
+            break;
+
+        default:
+            return PatchStatus::BadEscape;
+        }
+    }
+
+    return PatchStatus::Ok;
+}
+
+
+PatchStatus checkTarget(const PatchTarget& target)
+{
+    if (target.buffer == nullptr || target.capacity == 0)
+        return PatchStatus::BadTarget;
+
+    if (target.offset > target.bufferSize || target.capacity > target.bufferSize - target.offset)
+        return PatchStatus::BadTarget;
+
+    if (target.encoding == TextEncoding::Utf16LE && (target.capacity & 1) != 0)
+        return PatchStatus::BadEncoding;
+
+    return PatchStatus::Ok;
+}
+
+PatchResult prepare(const PatchTarget& target, const char* text, std::vector<uint32_t>& codePoints)
+{
+    PatchResult result;
+
+    result.status = checkTarget(target);
+    if (result.status != PatchStatus::Ok)
+        return result;
+
+    result.status = decodeSource(text, codePoints);
+    if (result.status != PatchStatus::Ok)
+        return result;
+
+    const bool wide = target.encoding == TextEncoding::Utf16LE;
+    const uint32_t terminator = wide ? 2u : 1u;
+
+    uint32_t needed = terminator;
+    for (uint32_t cp : codePoints)
+        needed += wide ? encodedSizeUtf16(cp) : encodedSizeUtf8(cp);
+
+    result.required = needed;
+
+    // Todo: change this if we prefer to write a partial line instead
+    // of not writing at all
+    if (needed > target.capacity)
+        result.status = PatchStatus::TooLong;
+
+    return result;
+}
+
+
+void encodeUtf8(uint32_t cp, uint8_t* out, uint32_t& at)
+{
+    if (cp < 0x80)
+    {
+        out[at++] = static_cast<uint8_t>(cp);
+    }
+    else if (cp < 0x800)
+    {
+        out[at++] = static_cast<uint8_t>(0xC0 | (cp >> 6));
+        out[at++] = static_cast<uint8_t>(0x80 | (cp & 0x3F));
+    }
+    else if (cp < 0x10000)
+    {
+        out[at++] = static_cast<uint8_t>(0xE0 | (cp >> 12));
+        out[at++] = static_cast<uint8_t>(0x80 | ((cp >> 6) & 0x3F));
+        out[at++] = static_cast<uint8_t>(0x80 | (cp & 0x3F));
+    }
+    else
+    {
+        out[at++] = static_cast<uint8_t>(0xF0 | (cp >> 18));
+        out[at++] = static_cast<uint8_t>(0x80 | ((cp >> 12) & 0x3F));
+        out[at++] = static_cast<uint8_t>(0x80 | ((cp >> 6) & 0x3F));
+        out[at++] = static_cast<uint8_t>(0x80 | (cp & 0x3F));
+    }
+}
+
+void encodeUtf16(uint32_t cp, uint8_t* out, uint32_t& at)
+{
+    if (cp < 0x10000)
+    {
+        out[at++] = static_cast<uint8_t>(cp & 0xFF);
+        out[at++] = static_cast<uint8_t>(cp >> 8);
+        return;
+    }
+
+    const uint32_t adjusted = cp - 0x10000;
+    const uint16_t high = static_cast<uint16_t>(0xD800 + (adjusted >> 10));
+    const uint16_t low = static_cast<uint16_t>(0xDC00 + (adjusted & 0x3FF));
+
+    out[at++] = static_cast<uint8_t>(high & 0xFF);
+    out[at++] = static_cast<uint8_t>(high >> 8);
+    out[at++] = static_cast<uint8_t>(low & 0xFF);
+    out[at++] = static_cast<uint8_t>(low >> 8);
+}
+
+PatchResult patchLine(const PatchTarget& target, const char* text, PadMode padMode)
+{
+    std::vector<uint32_t> codePoints;
+    PatchResult result = prepare(target, text, codePoints);
+
+    if (!result.ok())
+        return result;
+
+    const bool wide = target.encoding == TextEncoding::Utf16LE;
+    uint8_t* const slot = target.buffer + target.offset;
+
+    uint32_t at = 0;
+    for (uint32_t cp : codePoints)
+    {
+        if (wide)
+            encodeUtf16(cp, slot, at);
+        else
+            encodeUtf8(cp, slot, at);
+    }
+
+    slot[at++] = 0;
+    if (wide)
+        slot[at++] = 0;
+
+    result.written = at;
+
+    const uint8_t pad = (padMode == PadMode::Spaces) ? 0x20 : 0x00;
+
+    if (padMode == PadMode::Spaces && wide)
+    {
+        for (uint32_t i = at; i + 1 < target.capacity; i += 2)
+        {
+            slot[i] = 0x20;
+            slot[i + 1] = 0x00;
+        }
+    }
+    else
+    {
+        for (uint32_t i = at; i < target.capacity; ++i)
+            slot[i] = pad;
+    }
+
+    return result;
+}
+
+void copyBinaryBuffer(const uint8_t* srcData, uint32_t srcSize, uint8_t* targetData, uint32_t targetSize, uint32_t maxSize, PadMode padMode)
+{
+    if (targetSize <= maxSize)
+    {
+        std::memcpy((void*)targetData, srcData, srcSize);
+        int remaining = targetSize - srcSize;
+        if (remaining > 0)
+        {
+            uint8_t pad = 0x00;
+            if (padMode == PadMode::Spaces) { pad = 0x20; }
+            else if(padMode == PadMode::FF) { pad = 0xFF; }
+            memset((void*)(targetData + srcSize), pad, remaining);
+        }
+    }
+    else
+    {
+        assert(false);
+    }
+}
+
+bool patchCompressedSection(uint8_t* inputPtr, uint32_t inputSize, uint32_t maxSize, const std::vector<strings::CsvLine>& lines, bool bPadFF, uint32_t& out_size, uint32_t& out_count)
+{
+    ndsloc::LZSSFile previous(inputPtr, inputSize);
+    previous.decompress();
+
+    auto decompressed = previous.getConvertedData();
+    auto* data = decompressed.data();
+    auto dataSize = static_cast<uint32_t>(decompressed.size());
+
+    std::vector<String> strings;
+
+    if (cakp::isCAKP(data))
+    {
+        CAKPFile cakp(data, dataSize, "");
+        cakp.extractStrings(strings);
+    }
+    else if (StringTableFile::looksValid(data, dataSize))
+    {
+        std::vector<U16String> wide;
+        StringTableFile table(data, dataSize);
+        const bool ok = table.extractStrings(wide);
+        strings::appendWideStrings("", wide, strings);
+    }
+    else
+    {
+        CAKPFile cakp(data, dataSize, "");
+        cakp.extractSectionStrings(strings);
+    }
+
+    auto algo = previous.getCompressionMethod();
+
+    uint32_t linesToUpdate = 0;
+
+    for (auto& line : lines)
+    {
+        auto foundString = std::find_if(strings.begin(), strings.end(), [&](auto& e) { return e.offset == line.offset; });
+        assert(foundString != strings.end());
+        if (foundString != strings.end())
+        {
+            if (foundString->text != line.text)
+            {
+                PatchTarget target;
+                target.buffer = data;
+                target.bufferSize = dataSize;
+                target.offset = line.offset;
+                target.encoding = foundString->bIsWide ? TextEncoding::Utf16LE : TextEncoding::Utf8;
+                target.capacity = foundString->text.size() + 1;
+                if (foundString->bIsWide) { target.capacity *= 2; }
+
+                patchLine(target, line.text.c_str(), PadMode::Zero);
+                linesToUpdate++;
+            }
+        }
+    }
+
+    if (linesToUpdate > 0)
+    {
+        ndsloc::LZSSFile newer(decompressed.data(), decompressed.size());
+        newer.compress(algo);
+
+        auto newerData = newer.getConvertedData();
+
+        auto padMode = bPadFF ? PadMode::FF : PadMode::Zero;
+        copyBinaryBuffer(newerData.data(), newerData.size(), inputPtr, inputSize, maxSize, padMode);
+
+        out_size = newerData.size();
+        out_count = linesToUpdate;
+        return true;
+    }
+    else
+    {
+        out_size = 0;
+        out_count = 0;
+        return false;
+    }
+}
+
+} // namespace patcher
+} // namespace ndsloc

--- a/src/plugins/localization/rompatcher.h
+++ b/src/plugins/localization/rompatcher.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <cstdint>
+
+namespace NDS {
+struct NDSEntry;
+class NDSFileSystem;
+}
+
+namespace ndsloc {
+
+namespace strings {
+struct CsvNdsFile;
+struct CsvLine;
+}
+
+namespace patcher {
+
+uint32_t createPatch(const std::string& romPath, const std::vector<strings::CsvNdsFile>& modFiles);
+uint32_t createPatch(uint8_t* rom, uint32_t romSize, const std::vector<strings::CsvNdsFile>& modFiles);
+
+} // namespace patcher
+} // namespace ndsloc

--- a/src/plugins/localization/strings.cpp
+++ b/src/plugins/localization/strings.cpp
@@ -1,0 +1,351 @@
+#include "strings.h"
+
+#include "utils.h"
+
+#include <algorithm>
+#include <string>
+#include <iomanip>
+#include <fstream>
+#include <assert.h>
+
+#include "stringtable.h"
+
+namespace ndsloc {
+namespace strings {
+
+void appendWideStrings(const std::string& filename, const std::vector<U16String>& strings, std::vector<String>& out)
+{
+    for (auto& str : strings)
+    {
+        out.emplace_back(str.offset, utf16ToUtf8(str.text), std::string(filename), true);
+    }
+}
+
+void writeIniString(std::ofstream& os, int offset, const std::string& text)
+{
+    os << "0x" << std::uppercase << std::setfill('0') << std::setw(8) << std::hex << offset << "=";
+    os << text << "\n";
+}
+
+void writeIniString(std::ofstream& os, int offset, const std::u16string& text)
+{
+    writeIniString(os, offset, utf16ToUtf8(text));
+}
+
+static std::string csvEscape(const std::string& in)
+{
+    if (in.find_first_of(",\"\r\n") == std::string::npos)
+        return in;
+
+    std::string out;
+    out.reserve(in.size() + 2);
+    out.push_back('"');
+    for (char c : in) {
+        if (c == '"') out.push_back('"');
+        out.push_back(c);
+    }
+    out.push_back('"');
+    return out;
+}
+
+std::ofstream startFile(const std::string& outPathNoExt, ExportFormat format)
+{
+    std::string fullPath = outPathNoExt;
+    fullPath += (format == ExportFormat::Csv) ? ".csv" : ".ini";
+
+    std::ofstream os(fullPath, std::ios::binary);
+
+    if (format == ExportFormat::Csv)
+    {
+        os << "\xEF\xBB\xBF";
+        os << "file,subfile,offset,text\n";
+    }
+
+    return std::move(os);
+}
+
+void writeCsvLine(std::ofstream& os, const std::string& filename, const std::string& subfilename, int offset, const std::string& text)
+{
+    os << filename;
+    os << ',' << subfilename;
+    os << ",0x" << std::uppercase << std::setfill('0') << std::setw(4) << std::hex << offset;
+    os << ',' << csvEscape(text);
+    os << '\n';
+}
+
+void writeCsvLine(std::ofstream& os, const std::string& filename, const std::string& subfilename, int offset, const std::u16string& text)
+{
+    writeCsvLine(os, filename, subfilename, offset, utf16ToUtf8(text));
+}
+
+bool shouldIgnoreString(std::string str)
+{
+    if (str.empty()
+        || str.find("DELETED") != std::string::npos)
+        return true;
+
+    return false;
+}
+
+const std::string& getSection(const String& entry) { return entry.section; }
+
+const std::string& getSection(const U16String&) { static const std::string empty; return empty; }
+
+std::string getText(const String& entry) { return entry.text; }
+std::string getText(const U16String& entry) { return utf16ToUtf8(entry.text); }
+
+template <typename T>
+void writeStringsImpl(ExportFormat format, std::ofstream& os, uint32_t fileOffset, const std::string& filename, const std::vector<T>& strings)
+{
+    for (const auto& entry : strings)
+    {
+        std::string text = getText(entry);
+        if (shouldIgnoreString(text))
+            continue;
+
+        utils::replace_in_string(text, "\n", "\\n");
+        utils::replace_in_string(text, "\r", "\\r");
+
+        if (format == ExportFormat::Csv)
+            strings::writeCsvLine(os, filename, getSection(entry), entry.offset, text);
+        else
+            strings::writeIniString(os, fileOffset + entry.offset, text);
+    }
+}
+
+void writeStrings(ExportFormat format, std::ofstream& os, uint32_t fileOffset, const std::string& filename, const std::vector<String>& strings)
+{
+    writeStringsImpl(format, os, fileOffset, filename, strings);
+}
+ 
+void writeStrings(ExportFormat format, std::ofstream& os, uint32_t fileOffset, const std::string& filename, const std::vector<U16String>& strings)
+{
+    writeStringsImpl(format, os, fileOffset, filename, strings);
+}
+
+void consumeBom(std::istream& is)
+{
+    if (is.peek() != 0xEF)
+        return;
+
+    char bom[3] = {};
+    const std::streampos start = is.tellg();
+    if (is.read(bom, 3) && bom[0] == '\xEF' && bom[1] == '\xBB' && bom[2] == '\xBF')
+        return;
+
+    is.clear();
+    is.seekg(start);
+}
+
+bool readCsvRecord(std::istream& is, std::vector<std::string>& fields)
+{
+    fields.clear();
+
+    std::string field;
+    bool inQuotes = false;
+    bool quotedField = false;
+    bool gotAnything = false;
+
+    char c = 0;
+    while (is.get(c))
+    {
+        gotAnything = true;
+
+        if (inQuotes)
+        {
+            if (c == '"')
+            {
+                if (is.peek() == '"')
+                {
+                    is.get(c);
+                    field += '"';
+                }
+                else
+                {
+                    inQuotes = false;
+                }
+            }
+            else
+            {
+                field += c;
+            }
+            continue;
+        }
+
+        if (c == '"' && field.empty() && !quotedField)
+        {
+            inQuotes = true;
+            quotedField = true;
+        }
+        else if (c == ',')
+        {
+            fields.push_back(field);
+            field.clear();
+            quotedField = false;
+        }
+        else if (c == '\r')
+        {
+            // part of a CRLF line ending, ignore
+        }
+        else if (c == '\n')
+        {
+            fields.push_back(field);
+            return true;
+        }
+        else
+        {
+            field += c;
+        }
+    }
+
+    if (!gotAnything)
+        return false;
+
+    fields.push_back(field);
+    return true;
+}
+
+std::string trim(const std::string& s)
+{
+    const auto first = s.find_first_not_of(" \t");
+    if (first == std::string::npos)
+        return {};
+    const auto last = s.find_last_not_of(" \t");
+    return s.substr(first, last - first + 1);
+}
+
+int parseHex(const std::string& value, const char* columnName, size_t lineNumber)
+{
+    std::string s = trim(value);
+    if (s.size() > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))
+        s.erase(0, 2);
+
+    assert(!s.empty());
+
+    size_t consumed = 0;
+    const unsigned long parsed = std::stoul(s, &consumed, 16);
+    assert(consumed == s.size());
+    return static_cast<int>(parsed);
+}
+
+std::string unescapeText(const std::string& text)
+{
+    std::string out;
+    out.reserve(text.size());
+
+    for (size_t i = 0; i < text.size(); ++i)
+    {
+        if (text[i] == '\\' && i + 1 < text.size())
+        {
+            const char next = text[i + 1];
+            if (next == 'n') { out += '\n'; ++i; continue; }
+            if (next == 'r') { out += '\r'; ++i; continue; }
+        }
+        out += text[i];
+    }
+
+    return out;
+}
+
+std::vector<CsvNdsFile> readCsvFile(const std::string& inPath)
+{
+    std::ifstream is(inPath, std::ios::binary);
+    if (!is)
+    {
+        assert(false);
+        return {};
+    }
+
+    consumeBom(is);
+
+    std::vector<CsvNdsFile> files;
+    int currentFileId = -1;
+
+    std::vector<std::string> fields;
+    size_t lineNumber = 0;
+
+    while (readCsvRecord(is, fields))
+    {
+        ++lineNumber;
+
+        if (lineNumber == 1) // header
+            continue;
+
+        if (fields.size() == 1 && fields[0].empty()) // blank line
+            continue;
+
+        if (fields.size() < 4)
+        {
+            assert(false); // Invalid line (not enough columns)
+            continue;
+        }
+
+        const auto& filename = fields[0];
+        CsvNdsFile* currentFile = nullptr;
+
+        if (currentFileId != -1)
+        {
+            assert(currentFileId < files.size());
+            auto& file = files[currentFileId];
+            if (filename == file.filename)
+            {
+                currentFile = &file;
+            }
+            else
+            {
+                currentFileId = -1;
+            }
+        }
+
+        if (!currentFile)
+        {
+            auto found = std::find_if(files.begin(), files.end(), [filename](const auto& e) { return e.filename == filename; });
+            if (found != files.end())
+            {
+                currentFile = &(*found);
+                currentFileId = std::distance(files.begin(), found);
+            }
+            else
+            {
+                CsvNdsFile newFile;
+                newFile.filename = filename;
+                files.push_back(std::move(newFile));
+                currentFile = &files.back();
+                currentFileId = files.size() - 1;
+            }
+        }
+
+        assert(currentFile);
+
+        CsvLine entry;
+        entry.offset = parseHex(fields[2], "offset", lineNumber);
+        entry.text = unescapeText(fields[3]);
+
+        std::string subfilename = fields[1];
+        if (!subfilename.empty())
+        {
+            auto foundSub = std::find_if(currentFile->subfiles.begin(), currentFile->subfiles.end(), [subfilename](const auto& e) { return e.filename == subfilename; });
+            if (foundSub != currentFile->subfiles.end())
+            {
+                foundSub->lines.push_back(std::move(entry));
+            }
+            else
+            {
+                CsvNdsSubfile newSubFile;
+                newSubFile.filename = subfilename;
+                newSubFile.lines.push_back(std::move(entry));
+                currentFile->subfiles.push_back(std::move(newSubFile));
+            }
+        }
+        else
+        {
+            currentFile->lines.push_back(std::move(entry));
+        }
+    }
+
+    return std::move(files);
+}
+
+
+} // namespace strings
+} // namespace ndsloc

--- a/src/plugins/localization/strings.h
+++ b/src/plugins/localization/strings.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+#include "types.h"
+
+namespace ndsloc {
+enum EFileFormat : uint8_t;
+
+namespace strings {
+
+void appendWideStrings(const std::string& filename, const std::vector<U16String>& strings, std::vector<String>& out);
+
+std::ofstream startFile(const std::string& outPathNoExt, ExportFormat format);
+void writeStrings(ExportFormat format, std::ofstream& os, uint32_t fileOffset, const std::string& filename, const std::vector<String>& strings);
+void writeStrings(ExportFormat format, std::ofstream& os, uint32_t fileOffset, const std::string& filename, const std::vector<U16String>& strings);
+
+struct CsvLine
+{
+    int offset = 0;
+    std::string text;
+};
+
+struct CsvNdsSubfile
+{
+    std::string filename;
+
+    std::vector<CsvLine> lines;
+};
+
+struct CsvNdsFile
+{
+    std::string filename;
+
+    std::vector<CsvLine> lines;
+    std::vector<CsvNdsSubfile> subfiles;
+};
+
+
+std::vector<CsvNdsFile> readCsvFile(const std::string& inPath);
+
+} // namespace strings
+} // namespace ndsloc

--- a/src/plugins/localization/stringtable.cpp
+++ b/src/plugins/localization/stringtable.cpp
@@ -1,0 +1,459 @@
+#include "stringtable.h"
+
+#include "utils.h"
+#include "types.h"
+#include "strings.h"
+
+#include <assert.h>
+
+namespace ndsloc {
+
+StringTableFile::StringTableFile(const uint8_t* inputPtr, uint32_t inputSize)
+    : m_buffer(inputPtr)
+    , m_bufferSize(inputSize)
+    , m_format(detect(inputPtr, inputSize))
+{
+}
+
+void readEntry(const uint8_t* inputPtr, uint32_t at, stringtable::Entry& entry)
+{
+    entry.id = utils::readUInt16(inputPtr, at);
+    entry.titleLength = utils::readUInt16(inputPtr, at + 2);
+    entry.contentLength = utils::readUInt16(inputPtr, at + 4);
+    entry.extraLength = utils::readUInt16(inputPtr, at + 6);
+    entry.start = utils::readUInt32(inputPtr, at + 8);
+    entry.endTitle = utils::readUInt32(inputPtr, at + 12);
+    entry.endContent = utils::readUInt32(inputPtr, at + 16);
+}
+
+void readPagedHeader(const uint8_t* inputPtr, uint32_t at, stringtable::PagedHeader& header)
+{
+    header.size = utils::readUInt32(inputPtr, at);
+    header.titleOffset = utils::readUInt32(inputPtr, at + 4);
+    header.bodyOffset = utils::readUInt32(inputPtr, at + 8);
+    header.id = utils::readUInt16(inputPtr, at + 12);
+    header.extraCount = utils::readUInt16(inputPtr, at + 14);
+}
+
+bool walkRecords(const uint8_t* inputPtr, uint32_t inputSize, std::vector<stringtable::Record>& out)
+{
+    out.clear();
+
+    if (inputSize < stringtable::kShortHeaderSize)
+        return false;
+
+    if (utils::readUInt32(inputPtr, 0) != stringtable::kShortHeaderSize)
+        return false;
+
+    const uint32_t count = utils::readUInt32(inputPtr, 4);
+    if (count == 0 || count > inputSize / stringtable::kMinRecordSize)
+        return false;
+
+    uint32_t pos = stringtable::kShortHeaderSize;
+
+    while (pos < inputSize)
+    {
+        if (inputSize - pos < 4)
+            return false;
+
+        const uint32_t size = utils::readUInt24(inputPtr, pos);
+
+        if (size == 0)
+        {
+            if (pos + 4 != inputSize)
+                return false;
+
+            pos += 4;
+            break;
+        }
+
+        if (size < stringtable::kMinRecordSize || (size & 1) != 0 || size > inputSize - pos)
+            return false;
+
+        out.push_back({ pos, size });
+        pos += size;
+
+        if (out.size() > count)
+            return false;
+    }
+
+    return pos == inputSize && out.size() == count;
+}
+
+bool pagedRecordLooksValid(const uint8_t* inputPtr, const stringtable::Record& record)
+{
+    if (record.size < stringtable::kPagedHeaderSize + 4)
+        return false;
+
+    stringtable::PagedHeader header;
+    readPagedHeader(inputPtr, record.offset, header);
+
+    if (header.size != record.size)
+        return false;
+
+    if (header.extraCount > (record.size - stringtable::kPagedHeaderSize) / 4)
+        return false;
+
+    if (header.titleOffset != stringtable::kPagedHeaderSize + header.extraCount * 4)
+        return false;
+
+    if (header.bodyOffset <= header.titleOffset || header.bodyOffset >= record.size)
+        return false;
+
+    if ((header.bodyOffset & 1) != 0)
+        return false;
+
+    uint32_t pos = header.bodyOffset;
+    uint32_t pages = 0;
+
+    while (pos < record.size)
+    {
+        if (record.size - pos < 4)
+            return false;
+
+        const uint32_t size = utils::readUInt32(inputPtr, record.offset + pos);
+
+        if (size < stringtable::kMinRecordSize || (size & 1) != 0 || size > record.size - pos)
+            return false;
+
+        pos += size;
+        ++pages;
+    }
+
+    return pos == record.size && pages > 0;
+}
+
+
+bool looksLikeStringDB(const uint8_t* inputPtr, uint32_t inputSize)
+{
+    if (inputSize < 8)
+        return false;
+
+    const uint32_t count = utils::readUInt32(inputPtr, 0);
+
+    if (count == 0 || (count & 1) != 0)
+        return false;
+
+    if (count > (inputSize - 4) / 4)
+        return false;
+
+    const uint32_t dataAt = 4 + count * 4;
+    if (dataAt >= inputSize)
+        return false;
+
+    uint32_t previous = 0;
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        const uint32_t end = utils::readUInt32(inputPtr, 4 + i * 4);
+
+        if (end < previous || (end & 1) != 0)
+            return false;
+
+        if (end > inputSize - dataAt)
+            return false;
+
+        previous = end;
+    }
+
+    return dataAt + previous == inputSize;
+}
+
+bool looksLikeStringDBLong(const uint8_t* inputPtr, uint32_t inputSize)
+{
+    if (inputSize < 4 + stringtable::kEntrySize)
+        return false;
+
+    const uint32_t count = utils::readUInt32(inputPtr, 0);
+
+    if (count == 0 || count > (inputSize - 4) / stringtable::kEntrySize)
+        return false;
+
+    const uint32_t dataAt = 4 + count * stringtable::kEntrySize;
+    if (dataAt >= inputSize || ((inputSize - dataAt) & 1) != 0)
+        return false;
+
+    const uint32_t units = (inputSize - dataAt) / 2;
+
+    uint32_t expectedStart = 0;
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        stringtable::Entry entry;
+        readEntry(inputPtr, 4 + i * stringtable::kEntrySize, entry);
+
+        if (entry.start != expectedStart)
+            return false;
+
+        if (entry.start > entry.endTitle || entry.endTitle > entry.endContent)
+            return false;
+
+        if (entry.endTitle - entry.start != entry.titleLength)
+            return false;
+
+        if (entry.endContent - entry.endTitle != entry.contentLength)
+            return false;
+
+        if (entry.extraLength == 0 || entry.endContent > units - entry.extraLength)
+            return false;
+
+        expectedStart = entry.endContent + entry.extraLength;
+    }
+
+    return expectedStart == units;
+}
+
+bool looksLikeStringDBShort(const uint8_t* inputPtr, uint32_t inputSize)
+{
+    std::vector<stringtable::Record> records;
+    return walkRecords(inputPtr, inputSize, records);
+}
+
+bool looksLikeStringDBPaged(const uint8_t* inputPtr, uint32_t inputSize)
+{
+    std::vector<stringtable::Record> records;
+
+    if (!walkRecords(inputPtr, inputSize, records))
+        return false;
+
+    for (const stringtable::Record& record : records)
+    {
+        if (!pagedRecordLooksValid(inputPtr, record))
+            return false;
+    }
+
+    return true;
+}
+
+stringtable::Format StringTableFile::detect(const uint8_t* inputPtr, uint32_t inputSize)
+{
+    using namespace stringtable;
+
+    if (inputPtr == nullptr)
+        return Format::Unknown;
+
+    if (looksLikeStringDB(inputPtr, inputSize))
+        return Format::StringDB;
+
+    if (looksLikeStringDBLong(inputPtr, inputSize))
+        return Format::StringDB_Long;
+
+    if (looksLikeStringDBPaged(inputPtr, inputSize))
+        return Format::StringDB_Paged;
+
+    if (looksLikeStringDBShort(inputPtr, inputSize))
+        return Format::StringDB_Short;
+
+    return Format::Unknown;
+}
+
+void StringTableFile::addString(uint32_t at, uint32_t lengthInBytes, std::vector<U16String>& out) const
+{
+    if (at > m_bufferSize || lengthInBytes > m_bufferSize - at)
+        return;
+
+    std::u16string text;
+    text.reserve(lengthInBytes / 2);
+
+    for (uint32_t i = 0; i + 1 < lengthInBytes; i += 2)
+    {
+        const char16_t unit = static_cast<char16_t>(utils::readUInt16(m_buffer, at + i));
+
+        if (unit == 0)
+            break; // NULL terminator
+
+        text.push_back(unit);
+    }
+
+    out.emplace_back(at, std::move(text));
+}
+
+bool StringTableFile::extractStringDB(std::vector<U16String>& out) const
+{
+    const uint32_t count = utils::readUInt32(m_buffer, 0);
+    const uint32_t dataAt = 4 + count * 4;
+
+    out.reserve(count);
+
+    uint32_t start = 0;
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        const uint32_t end = utils::readUInt32(m_buffer, 4 + i * 4);
+
+        addString(dataAt + start, end - start, out);
+        start = end;
+    }
+
+    return true;
+}
+
+bool StringTableFile::extractStringDBLong(std::vector<U16String>& out) const
+{
+    const uint32_t count = utils::readUInt32(m_buffer, 0);
+    const uint32_t dataAt = 4 + count * stringtable::kEntrySize;
+
+    out.reserve(count * 3);
+
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        stringtable::Entry entry;
+        readEntry(m_buffer, 4 + i * stringtable::kEntrySize, entry);
+
+        addString(dataAt + entry.start * 2, entry.titleLength * 2, out);
+        addString(dataAt + entry.endTitle * 2, entry.contentLength * 2, out);
+        addString(dataAt + entry.endContent * 2, entry.extraLength * 2, out);
+    }
+
+    return true;
+}
+
+bool StringTableFile::extractStringDBShort(std::vector<U16String>& out) const
+{
+    std::vector<stringtable::Record> records;
+    if (!walkRecords(m_buffer, m_bufferSize, records))
+        return false;
+
+    out.reserve(records.size());
+
+    for (const stringtable::Record& record : records)
+        addString(record.offset + 4, record.size - 4, out);
+
+    return true;
+}
+
+bool StringTableFile::extractStringDBPaged(std::vector<U16String>& out) const
+{
+    std::vector<stringtable::Record> records;
+    if (!walkRecords(m_buffer, m_bufferSize, records))
+        return false;
+
+    out.reserve(records.size() * 2);
+
+    for (const stringtable::Record& record : records)
+    {
+        stringtable::PagedHeader header;
+        readPagedHeader(m_buffer, record.offset, header);
+
+        addString(record.offset + header.titleOffset,
+            header.bodyOffset - header.titleOffset, out);
+
+        uint32_t pos = header.bodyOffset;
+        while (pos < record.size)
+        {
+            const uint32_t size = utils::readUInt32(m_buffer, record.offset + pos);
+
+            addString(record.offset + pos + 4, size - 4, out);
+            pos += size;
+        }
+    }
+
+    return true;
+}
+
+bool StringTableFile::readRecords(std::vector<stringtable::Record>& out) const
+{
+    out.clear();
+
+    if (m_format != stringtable::Format::StringDB_Short && m_format != stringtable::Format::StringDB_Paged)
+        return false;
+
+    return walkRecords(m_buffer, m_bufferSize, out);
+}
+
+bool StringTableFile::extractStrings(std::vector<U16String>& out) const
+{
+    using namespace stringtable;
+
+    out.clear();
+
+    switch (m_format)
+    {
+    case Format::StringDB:
+        return extractStringDB(out);
+    case Format::StringDB_Long:
+        return extractStringDBLong(out);
+    case Format::StringDB_Short:
+        return extractStringDBShort(out);
+    case Format::StringDB_Paged:
+        return extractStringDBPaged(out);
+    default:
+        return false;
+    }
+}
+
+bool StringTableFile::looksValid(const uint8_t* inputPtr, uint32_t inputSize)
+{
+    return detect(inputPtr, inputSize) != stringtable::Format::Unknown;
+}
+
+uint32_t StringTableFile::exportStrings(std::ofstream& os, const std::vector<uint8_t>& in_data, ndsloc::ExportFormat format, const std::string& filename, const std::string& ext, uint32_t offset)
+{
+    std::vector<U16String> out_strings;
+
+    const uint8_t* data = in_data.data();
+    const uint32_t dataSize = static_cast<uint32_t>(in_data.size());
+
+    StringTableFile table(data, dataSize);
+
+    if (table.getFormat() != stringtable::Format::Unknown)
+    {
+        table.extractStrings(out_strings);
+    }
+    else
+    {
+        // Unrecognized format (probably not string table)
+    }
+
+    if (utils::ends_with(ext, "s.z") && table.getFormat() != stringtable::Format::StringDB_Short)
+        assert(false);
+
+    strings::writeStrings(format, os, offset, filename, out_strings);
+
+    return out_strings.size();
+}
+
+std::string utf16ToUtf8(const std::u16string& in)
+{
+    std::string out;
+    out.reserve(in.size());
+
+    for (size_t i = 0; i < in.size(); ++i)
+    {
+        uint32_t cp = in[i];
+
+        if (cp >= 0xD800 && cp <= 0xDBFF && i + 1 < in.size())
+        {
+            const uint32_t low = in[i + 1];
+            if (low >= 0xDC00 && low <= 0xDFFF)
+            {
+                cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
+                ++i;
+            }
+        }
+
+        if (cp < 0x80)
+        {
+            out.push_back(static_cast<char>(cp));
+        }
+        else if (cp < 0x800)
+        {
+            out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+            out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+        }
+        else if (cp < 0x10000)
+        {
+            out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+            out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+            out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+        }
+        else
+        {
+            out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+            out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+            out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+            out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+        }
+    }
+
+    return out;
+}
+
+} // namespace ndsloc

--- a/src/plugins/localization/stringtable.h
+++ b/src/plugins/localization/stringtable.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <stdint.h>
+#include <vector>
+#include <string>
+
+namespace ndsloc {
+
+enum ExportFormat : uint8_t;
+struct U16String;
+
+namespace stringtable {
+
+enum class Format : uint8_t
+{
+    Unknown,
+    StringDB,
+    StringDB_Long,
+    StringDB_Short,
+    StringDB_Paged
+};
+
+struct Entry
+{
+    uint16_t id = 0;
+    uint16_t titleLength = 0;
+    uint16_t contentLength = 0;
+    uint16_t extraLength = 0;
+    uint32_t start = 0;
+    uint32_t endTitle = 0;
+    uint32_t endContent = 0;
+};
+
+struct Record
+{
+    uint32_t offset = 0;
+    uint32_t size = 0;
+};
+
+struct PagedHeader
+{
+    uint32_t size = 0;
+    uint32_t titleOffset = 0;
+    uint32_t bodyOffset = 0;
+    uint16_t id = 0;
+    uint16_t extraCount = 0;
+};
+
+static const uint32_t kEntrySize = 20;
+static const uint32_t kShortHeaderSize = 8;
+static const uint32_t kPagedHeaderSize = 0x10;
+static const uint32_t kMinRecordSize = 6;
+
+static const char16_t kHighlightEnd = 0x0001;
+static const char16_t kHighlightBegin = 0x0002;
+static const char16_t kLineBreak = 0x000A;
+
+} // namespace stringtable
+
+class StringTableFile
+{
+public:
+    StringTableFile(const uint8_t* inputPtr, uint32_t inputSize);
+
+    bool extractStrings(std::vector<U16String>& out) const;
+
+    static bool looksValid(const uint8_t* inputPtr, uint32_t inputSize);
+    static uint32_t exportStrings(std::ofstream& os, const std::vector<uint8_t>& data, ndsloc::ExportFormat format, const std::string& filename, const std::string& ext, uint32_t offset);
+
+private:
+    stringtable::Format getFormat() const { return m_format; }
+
+    static stringtable::Format detect(const uint8_t* inputPtr, uint32_t inputSize);
+
+    bool readRecords(std::vector<stringtable::Record>& out) const;
+
+    bool extractStringDB(std::vector<U16String>& out) const;
+    bool extractStringDBLong(std::vector<U16String>& out) const;
+    bool extractStringDBShort(std::vector<U16String>& out) const;
+    bool extractStringDBPaged(std::vector<U16String>& out) const;
+
+    void addString(uint32_t at, uint32_t lengthInBytes, std::vector<U16String>& out) const;
+
+    const uint8_t* m_buffer = nullptr;
+    uint32_t m_bufferSize = 0;
+
+    stringtable::Format m_format = stringtable::Format::Unknown;
+};
+
+std::string utf16ToUtf8(const std::u16string& in);
+
+} // namespace ndsloc

--- a/src/plugins/localization/types.h
+++ b/src/plugins/localization/types.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <stdint.h>
+#include <string>
+
+namespace ndsloc {
+
+enum ExportFormat : uint8_t { Csv, Ini };
+
+struct String
+{
+    String(uint32_t in_off, std::string&& in_text, std::string&& in_section, bool in_wide)
+        : offset(in_off)
+        , text(std::move(in_text))
+        , section(std::move(in_section))
+        , bIsWide(in_wide)
+    {
+    }
+
+    uint32_t offset = 0;
+    std::string text;
+
+    std::string section;
+    bool bIsWide = false;
+};
+
+struct U16String
+{
+    U16String(uint32_t in_off, std::u16string&& in_text)
+        : offset(in_off)
+        , text(std::move(in_text))
+    { }
+
+    uint32_t offset = 0;
+    std::u16string text;
+};
+
+} // namespace ndsloc

--- a/src/plugins/localization/utils.cpp
+++ b/src/plugins/localization/utils.cpp
@@ -1,0 +1,116 @@
+#include "utils.h"
+
+#include <fstream>
+#include <iostream>
+#include <assert.h>
+
+#include "p2.h"
+#include "cakp.h"
+
+namespace utils {
+
+std::vector<uint8_t> readBinaryFile(const std::string& filename)
+{
+    std::ifstream file(filename, std::ios::binary);
+    if (!file)
+    {
+        std::cout << "Could not open file: " << filename << std::endl;
+        return {};
+    }
+
+    return std::vector<uint8_t>((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+}
+
+void saveBinaryFile(const std::vector<uint8_t>& data, const std::string& filename)
+{
+    if (data.size() > 0)
+    {
+        std::ofstream os(filename, std::ofstream::binary);
+        os.write((char*)data.data(), data.size());
+    }
+}
+
+ndsloc::EFileFormat getFileFormat(const void* data, std::size_t size)
+{
+    using namespace ndsloc;
+
+    if (!data || size == 0)
+        return EFileFormat::Empty;
+
+    const uint8_t* dataPtr = reinterpret_cast<const uint8_t*>(data);
+    const uint32_t dataSize = static_cast<uint32_t>(size);
+
+    if (p2::isP2File(dataPtr))
+        return EFileFormat::P2;
+
+    if (cakp::isCAKP(dataPtr))
+        return EFileFormat::CAKP;
+
+    return EFileFormat::Unknown;
+}
+
+std::string getExtName(ndsloc::EFileFormat type)
+{
+    using namespace ndsloc;
+    switch (type)
+    {
+    case EFileFormat::Empty: return "Empty";
+    case EFileFormat::P2: return "P2";
+    case EFileFormat::CAKP: return "CAKP";
+    default:
+        return "";
+    }
+}
+
+bool ends_with(const std::string& str, const std::string& suffix)
+{
+    return str.size() >= suffix.size()
+        && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+void replace_in_string(std::string& str, const std::string& replace, const std::string& with)
+{
+    size_t index = 0;
+    while (true)
+    {
+        index = str.find(replace, index);
+        if (index == std::string::npos)
+            break;
+
+        str.replace(index, replace.size(), with);
+
+        index += with.size();
+    }
+}
+
+void replace_in_ustring(std::u16string& str, const std::u16string& replace, const std::u16string& with)
+{
+    size_t index = 0;
+    while (true)
+    {
+        index = str.find(replace, index);
+        if (index == std::u16string::npos)
+            break;
+
+        str.replace(index, replace.size(), with);
+
+        index += with.size();
+    }
+}
+
+uint16_t readUInt16(const uint8_t* dataPtr, uint32_t pos)
+{
+    return dataPtr[pos] + (dataPtr[pos + 1] << 8);
+}
+
+uint32_t readUInt24(const uint8_t* dataPtr, uint32_t pos)
+{
+    return dataPtr[pos] + (dataPtr[pos + 1] << 8) + (dataPtr[pos + 2] << 16);
+}
+
+uint32_t readUInt32(const uint8_t* dataPtr, uint32_t pos)
+{
+    return dataPtr[pos] + (dataPtr[pos + 1] << 8) + (dataPtr[pos + 2] << 16) + (dataPtr[pos + 3] << 24);
+}
+
+} // namespace Utils

--- a/src/plugins/localization/utils.h
+++ b/src/plugins/localization/utils.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <cstdint>
+
+namespace ndsloc {
+
+enum EFileFormat : uint8_t
+{
+	Unknown = 0,
+	Empty,
+	P2,
+	CAKP,
+};
+
+}
+
+namespace utils {
+
+	std::vector<uint8_t> readBinaryFile(const std::string& filename);
+	void saveBinaryFile(const std::vector<uint8_t>& data, const std::string& filename);
+
+	ndsloc::EFileFormat getFileFormat(const void* data, std::size_t size);
+	std::string getExtName(ndsloc::EFileFormat type);
+
+	bool ends_with(const std::string& str, const std::string& suffix);
+	void replace_in_string(std::string& str, const std::string& replace, const std::string& with);
+	void replace_in_ustring(std::u16string& str, const std::u16string& replace, const std::u16string& with);
+
+	uint16_t readUInt16(const uint8_t* dataPtr, uint32_t pos);
+	uint32_t readUInt24(const uint8_t* dataPtr, uint32_t pos);
+	uint32_t readUInt32(const uint8_t* dataPtr, uint32_t pos);
+
+} // namespace Utils


### PR DESCRIPTION
- manual copy of the systems from https://github.com/justedni/nds_loc_utils (I made the modules generic to go back and forth from standalone tool, to integrated window in MelonDS)
- replaced old system in PluginKingdomHeartsDays::loadLocalization() with new system
- added new UI "Filesystem / Localization" (just under RAM search in the UI)

Complete workflow:
- open the new "Filesystem / Localization" menu. It automatically parses the filesystem and ticks all the files.
- click on "Export strings to CSV" (select which language to export first). The code scans ALL the internal files but will quickly skip any fileformat that is unlikely to contain strings.
- you can then modify the files and place them inside "assets/days/localization/us" (for now, hard-coded selection always takes "en-US.csv")
- string replacement at startup automatically re-scans the whole rom to get a "reference" table of strings, then compares it with the strings you provided. It will only replace strings that you have changed. This is important because while decompression of strings is quite fast (to retrieve the list), re-compression has a significant cost.
If you step into the code right after the call to ndsloc::patcher::createPatch, it will return how many strings were replaced (if it returns 0, it means no binary data was replaced in the loaded rom)
Note to myself: I should probably print that information somewhere visible? Like "N localized strings were replaced at startup".