### PR TITLE
Loc pipeline: lang fixes and missing table format for Recoded

### DIFF
--- a/src/frontend/qt_sdl/localization/FileSystemDialog.cpp
+++ b/src/frontend/qt_sdl/localization/FileSystemDialog.cpp
@@ -22,7 +22,7 @@ FileSystemDialog::FileSystemDialog(QWidget* parent)
     QVBoxLayout* layout = new QVBoxLayout(this);
 
     auto* locUtils = new LocUtils(this);
-    locUtils->setPlugin(emuInstance->plugin);
+    locUtils->setLocHandler(emuInstance->plugin);
 
     auto* cart = emuInstance->getNDS()->GetNDSCart();
     locUtils->loadRomData((uint8_t*)cart->GetROM(), cart->GetROMLength());

--- a/src/frontend/qt_sdl/localization/LocUtils.cpp
+++ b/src/frontend/qt_sdl/localization/LocUtils.cpp
@@ -19,7 +19,7 @@
 
 #include "localization/lang.h"
 #include "localization/strings.h"
-#include "plugins/Plugin.h"
+#include "localization/handler.h"
 
 namespace
 {
@@ -160,10 +160,10 @@ void LocUtils::on_buttonExportStringsToCsv_clicked()
     const int8_t lang = selectedLanguage();
     QString startDir;
 
-    if (m_plugin != nullptr)
+    if (m_handler != nullptr)
     {
         const auto probeLang = (lang == -1) ? ndsloc::Language::LANG_EN : static_cast<ndsloc::Language>(lang);
-        const std::string localizationFilePath = m_plugin->localizationFilePath(ndsloc::getLanguageFileName(probeLang), false);
+        const std::string localizationFilePath = m_handler->getLocalizationFilePath(ndsloc::getLanguageFileName(probeLang));
 
         if (!localizationFilePath.empty())
         {
@@ -183,6 +183,7 @@ void LocUtils::on_buttonExportStringsToCsv_clicked()
         return;
 
     beginTask();
+    m_worker->setLocHandler(m_handler);
     emit requestExportStrings(path, files, ndsloc::ExportFormat::Csv, lang);
 }
 

--- a/src/frontend/qt_sdl/localization/LocUtils.h
+++ b/src/frontend/qt_sdl/localization/LocUtils.h
@@ -14,7 +14,7 @@
 class QTreeWidgetItem;
 class Worker;
 
-namespace Plugins { class Plugin; }
+namespace Plugins { class LocalizationHandler; }
 
 class LocUtils : public QWidget
 {
@@ -29,7 +29,7 @@ public:
 
     bool isBusy() const { return m_bIsBusy; }
 
-    void setPlugin(Plugins::Plugin* plugin) { m_plugin = plugin; }
+    void setLocHandler(Plugins::LocalizationHandler* handler) { m_handler = handler; }
 signals:
     void busyChanged(bool busy);
     void requestLoadRom(const QString& romPath);
@@ -108,5 +108,5 @@ private:
     QString m_lastExtractFolder;
     QHash<QString, QTreeWidgetItem*> m_fileItems;
 
-    Plugins::Plugin* m_plugin = nullptr;
+    Plugins::LocalizationHandler* m_handler = nullptr;
 };

--- a/src/frontend/qt_sdl/localization/Worker.cpp
+++ b/src/frontend/qt_sdl/localization/Worker.cpp
@@ -9,6 +9,7 @@
 #include "localization/strings.h"
 #include "localization/stringtable.h"
 #include "localization/lzss.h"
+#include "localization/handler.h"
 
 #include <QFileInfo>
 #include <QDir>
@@ -270,6 +271,9 @@ void Worker::exportStrings(const QString& outFolder, const QStringList& files, u
                     if (shouldIgnoreFile(entry->filename, lang))
                         continue;
 
+                    if (m_handler && m_handler->shouldExcludeLocalizationSubfile(entry->filename))
+                        continue;
+
                     std::vector<String> out_strings;
                     p2.setLanguage(lang);
                     p2.extractStrings(out_strings);
@@ -293,6 +297,9 @@ void Worker::exportStrings(const QString& outFolder, const QStringList& files, u
                 {
                     auto lang = static_cast<Language>(os.first);
                     if (shouldIgnoreFile(entry->filename, lang))
+                        continue;
+
+                    if (m_handler && m_handler->shouldExcludeLocalizationSubfile(entry->filename))
                         continue;
 
                     uint32_t count = StringTableFile::exportStrings(os.second, lzss.getConvertedData(), format, filenameInCsv, fileInfo.suffix().toStdString(), entry->start);

--- a/src/frontend/qt_sdl/localization/Worker.h
+++ b/src/frontend/qt_sdl/localization/Worker.h
@@ -9,6 +9,10 @@ namespace NDS {
 class NDSFileSystem;
 }
 
+namespace Plugins {
+class LocalizationHandler;
+}
+
 class Worker : public QObject
 {
     Q_OBJECT
@@ -16,6 +20,8 @@ class Worker : public QObject
 public:
     explicit Worker(QObject* parent = nullptr);
     ~Worker() override;
+
+    void setLocHandler(Plugins::LocalizationHandler* handler) { m_handler = handler; }
 
 public slots:
     void loadRom(const QString& romPath);
@@ -44,4 +50,6 @@ private:
     std::vector<uint8_t> m_romBuffer;
     uint8_t* m_romData = nullptr;
     uint32_t m_romDataSize = 0;
+
+    Plugins::LocalizationHandler* m_handler = nullptr;
 };

--- a/src/plugins/Plugin.h
+++ b/src/plugins/Plugin.h
@@ -34,6 +34,8 @@
 #include "./PluginMenuStrings.h"
 #include "./PluginShapes.h"
 
+#include "localization/handler.h"
+
 namespace Plugins
 {
 using namespace melonDS;
@@ -144,7 +146,7 @@ struct TextureEntry
 
 struct ThemeColor { u8 r, g, b; };
 
-class Plugin
+class Plugin : public LocalizationHandler
 {
 protected:
     melonDS::NDS* nds = nullptr;
@@ -251,6 +253,7 @@ public:
     }
 
     virtual std::string localizationFilePath(std::string language, bool emptyIfFileNotFound);
+    std::string getLocalizationFilePath(std::string language) override { return localizationFilePath(language, false); }
 
     virtual std::string textureIndexFilePath();
     virtual std::map<std::string, TextureEntry>& getTexturesIndex();

--- a/src/plugins/PluginKingdomHeartsReCoded.cpp
+++ b/src/plugins/PluginKingdomHeartsReCoded.cpp
@@ -3134,6 +3134,14 @@ std::string PluginKingdomHeartsReCoded::localizationFilePath(std::string languag
     return "";
 }
 
+bool PluginKingdomHeartsReCoded::shouldExcludeLocalizationSubfile(std::string filename)
+{
+    if (filename.find("/wxc/wlm3_en.s.z") != std::string::npos)
+        return true;
+
+    return false;
+}
+
 u8 PluginKingdomHeartsReCoded::getFloorLevel()
 {
     u32 placeIdentAddr = getU32ByCart(BUG_SECTOR_IDENTIFIER_ADDRESS_US, BUG_SECTOR_IDENTIFIER_ADDRESS_EU, BUG_SECTOR_IDENTIFIER_ADDRESS_JP);

--- a/src/plugins/PluginKingdomHeartsReCoded.h
+++ b/src/plugins/PluginKingdomHeartsReCoded.h
@@ -60,6 +60,7 @@ public:
 
     std::string replacementCutsceneFilePath(CutsceneEntry* cutscene) override;
     std::string localizationFilePath(std::string language, bool emptyIfFileNotFound) override;
+    bool shouldExcludeLocalizationSubfile(std::string filename) override;
     std::filesystem::path patchReplacementCutsceneIfNeeded(CutsceneEntry* cutscene, std::filesystem::path folderPath);
     bool isUnskippableMobiCutscene(CutsceneEntry* cutscene) override;
 

--- a/src/plugins/localization/handler.h
+++ b/src/plugins/localization/handler.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+namespace Plugins {
+
+class LocalizationHandler
+{
+public:
+    virtual std::string getLocalizationFilePath(std::string language) = 0;
+    virtual bool shouldExcludeLocalizationSubfile(std::string filename) { return false; }
+};
+
+} // namespace Plugins

--- a/src/plugins/localization/lang.cpp
+++ b/src/plugins/localization/lang.cpp
@@ -46,17 +46,17 @@ bool shouldIgnoreFile(const std::string& filename, Language language)
         str = filename.substr(0, idx);
     }
 
-    if ((utils::ends_with(str,"_en") || str.find("/en/") != std::string::npos) && language != Language::LANG_EN)
+    if ((utils::ends_with(str,"en") || str.find("/en/") != std::string::npos) && language != Language::LANG_EN)
         return true;
-    else if ((utils::ends_with(str,"_fr") || str.find("/fr/") != std::string::npos) && language != Language::LANG_FR)
+    else if ((utils::ends_with(str,"fr") || str.find("/fr/") != std::string::npos) && language != Language::LANG_FR)
         return true;
-    else if ((utils::ends_with(str,"_ja") || str.find("/ja/") != std::string::npos) && language != Language::LANG_JP)
+    else if ((utils::ends_with(str,"ja") || str.find("/ja/") != std::string::npos) && language != Language::LANG_JP)
         return true;
-    else if ((utils::ends_with(str,"_de") || str.find("/de/") != std::string::npos) && language != Language::LANG_DE)
+    else if ((utils::ends_with(str,"de") || str.find("/de/") != std::string::npos) && language != Language::LANG_DE)
         return true;
-    else if ((utils::ends_with(str,"_es") || str.find("/es/") != std::string::npos) && language != Language::LANG_ES)
+    else if ((utils::ends_with(str,"es") || str.find("/es/") != std::string::npos) && language != Language::LANG_ES)
         return true;
-    else if ((utils::ends_with(str,"_it") || str.find("/it/") != std::string::npos) && language != Language::LANG_IT)
+    else if ((utils::ends_with(str,"it") || str.find("/it/") != std::string::npos) && language != Language::LANG_IT)
         return true;
 
     return false;

--- a/src/plugins/localization/stringtable.cpp
+++ b/src/plugins/localization/stringtable.cpp
@@ -4,6 +4,7 @@
 #include "types.h"
 #include "strings.h"
 
+#include <algorithm>
 #include <assert.h>
 
 namespace ndsloc {
@@ -223,6 +224,117 @@ bool looksLikeStringDBPaged(const uint8_t* inputPtr, uint32_t inputSize)
     return true;
 }
 
+uint32_t stringEnd(const uint8_t* inputPtr, uint32_t inputSize, uint32_t at)
+{
+    if ((at & 1) != 0 || at + 2 > inputSize)
+        return 0;
+
+    for (uint32_t p = at; p + 2 <= inputSize; p += 2)
+    {
+        if (utils::readUInt16(inputPtr, p) == 0)
+            return p + 2;
+    }
+
+    return 0;
+}
+
+bool looksLikeStringDBOffsets(const uint8_t* inputPtr, uint32_t inputSize)
+{
+    if (inputSize < 8 || (inputSize & 1) != 0)
+        return false;
+
+    const uint32_t dataAt = utils::readUInt32(inputPtr, 0);
+
+    if (dataAt < 4 || (dataAt & 3) != 0 || dataAt >= inputSize)
+        return false;
+
+    const uint32_t count = dataAt / 4;
+
+    std::vector<uint32_t> offsets;
+    offsets.reserve(count);
+
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        const uint32_t offset = utils::readUInt32(inputPtr, i * 4);
+
+        if (offset < dataAt || offset >= inputSize || (offset & 1) != 0)
+            return false;
+
+        if (stringEnd(inputPtr, inputSize, offset) == 0)
+            return false;
+
+        offsets.push_back(offset);
+    }
+
+    std::sort(offsets.begin(), offsets.end());
+    offsets.erase(std::unique(offsets.begin(), offsets.end()), offsets.end());
+
+    uint32_t expected = dataAt;
+    for (uint32_t offset : offsets)
+    {
+        if (offset != expected)
+            return false;
+
+        expected = stringEnd(inputPtr, inputSize, offset);
+    }
+
+    return expected == inputSize;
+}
+
+uint32_t resolveGroupCount(const uint8_t* inputPtr, uint32_t inputSize)
+{
+    if (inputSize < 8 || (inputSize & 1) != 0)
+        return 0;
+
+    uint32_t prefix = 0;
+    while ((prefix + 1) * 4 <= inputSize)
+    {
+        const uint32_t value = utils::readUInt32(inputPtr, prefix * 4);
+        const uint32_t maxStrings = (inputSize - (prefix + 1) * 4) / 4;
+
+        if (value == 0 || value > maxStrings)
+            break;
+
+        if (prefix > 0 && value <= utils::readUInt32(inputPtr, (prefix - 1) * 4))
+            break;
+
+        ++prefix;
+    }
+
+    for (uint32_t count = prefix; count >= 1; --count)
+    {
+        const uint32_t dataAt = count * 4;
+        const uint32_t total = utils::readUInt32(inputPtr, (count - 1) * 4);
+
+        uint32_t at = dataAt;
+        uint32_t strings = 0;
+
+        while (at < inputSize)
+        {
+            const uint32_t end = stringEnd(inputPtr, inputSize, at);
+            if (end == 0)
+                break;
+
+            at = end;
+            ++strings;
+
+            if (strings > total)
+                break;
+        }
+
+        if (at == inputSize && strings == total)
+            return count;
+    }
+
+    return 0;
+}
+
+bool looksLikeStringDBGrouped(const uint8_t* inputPtr, uint32_t inputSize)
+{
+    return resolveGroupCount(inputPtr, inputSize) != 0;
+}
+
+
 stringtable::Format StringTableFile::detect(const uint8_t* inputPtr, uint32_t inputSize)
 {
     using namespace stringtable;
@@ -241,6 +353,12 @@ stringtable::Format StringTableFile::detect(const uint8_t* inputPtr, uint32_t in
 
     if (looksLikeStringDBShort(inputPtr, inputSize))
         return Format::StringDB_Short;
+
+    if (looksLikeStringDBOffsets(inputPtr, inputSize))
+        return Format::StringDB_Offsets;
+
+    if (looksLikeStringDBGrouped(inputPtr, inputSize))
+        return Format::StringDB_Grouped;
 
     return Format::Unknown;
 }
@@ -348,6 +466,47 @@ bool StringTableFile::extractStringDBPaged(std::vector<U16String>& out) const
     return true;
 }
 
+
+bool StringTableFile::extractStringDBOffsets(std::vector<U16String>& out) const
+{
+    const uint32_t dataAt = utils::readUInt32(m_buffer, 0);
+    const uint32_t count = dataAt / 4;
+
+    out.reserve(count);
+
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        const uint32_t offset = utils::readUInt32(m_buffer, i * 4);
+        addString(offset, stringEnd(m_buffer, m_bufferSize, offset) - offset, out);
+    }
+
+    return true;
+}
+
+bool StringTableFile::extractStringDBGrouped(std::vector<U16String>& out) const
+{
+    const uint32_t count = resolveGroupCount(m_buffer, m_bufferSize);
+    if (count == 0)
+        return false;
+
+    const uint32_t total = utils::readUInt32(m_buffer, (count - 1) * 4);
+
+    out.reserve(total);
+
+    uint32_t at = count * 4;
+    while (at < m_bufferSize)
+    {
+        const uint32_t end = stringEnd(m_buffer, m_bufferSize, at);
+        if (end == 0)
+            break;
+
+        addString(at, end - at, out);
+        at = end;
+    }
+
+    return true;
+}
+
 bool StringTableFile::readRecords(std::vector<stringtable::Record>& out) const
 {
     out.clear();
@@ -374,6 +533,10 @@ bool StringTableFile::extractStrings(std::vector<U16String>& out) const
         return extractStringDBShort(out);
     case Format::StringDB_Paged:
         return extractStringDBPaged(out);
+    case Format::StringDB_Offsets:
+        return extractStringDBOffsets(out);
+    case Format::StringDB_Grouped:
+        return extractStringDBGrouped(out);
     default:
         return false;
     }

--- a/src/plugins/localization/stringtable.h
+++ b/src/plugins/localization/stringtable.h
@@ -17,7 +17,9 @@ enum class Format : uint8_t
     StringDB,
     StringDB_Long,
     StringDB_Short,
-    StringDB_Paged
+    StringDB_Paged,
+    StringDB_Offsets,
+    StringDB_Grouped
 };
 
 struct Entry
@@ -78,6 +80,8 @@ private:
     bool extractStringDBLong(std::vector<U16String>& out) const;
     bool extractStringDBShort(std::vector<U16String>& out) const;
     bool extractStringDBPaged(std::vector<U16String>& out) const;
+    bool extractStringDBOffsets(std::vector<U16String>& out) const;
+    bool extractStringDBGrouped(std::vector<U16String>& out) const;
 
     void addString(uint32_t at, uint32_t lengthInBytes, std::vector<U16String>& out) const;
 


### PR DESCRIPTION
- removed dependency to Plugin.h by introducing abstract class localization/handler.h
- found missing strings in Re:Coded, the game has two new "string table/db" format types
- excluding wlm3_en.s.z from Re:Coded (it's a blacklist filter of banned words for the game's online mode)